### PR TITLE
Add a way to proxy module imports to a local repo

### DIFF
--- a/resolvers.js
+++ b/resolvers.js
@@ -1,0 +1,1 @@
+exports.LocalModuleProxy = require('./resolvers/localModuleProxy');

--- a/resolvers/localModuleProxy.js
+++ b/resolvers/localModuleProxy.js
@@ -1,0 +1,23 @@
+
+module.exports = class LocalModuleProxy {
+  constructor(opts) {
+    this.opts = opts;
+  }
+  apply(resolver) {
+    const self = this;
+    resolver.plugin('module', function (request, callback) {
+      const { moduleName, path } = self.opts;
+      if (moduleName === request.request) {
+        const proxyReq = {
+          path: request.path,
+          request: path,
+          query: request.query,
+          directory: request.directory,
+        };
+        this.doResolve(['file'], proxyReq, callback);
+      } else {
+        callback();
+      }
+    });
+  }
+};

--- a/resolvers/localModuleProxy.test.js
+++ b/resolvers/localModuleProxy.test.js
@@ -1,0 +1,37 @@
+import expect, { createSpy } from 'expect';
+import LocalModuleProxy from './localModuleProxy';
+
+function stub() {}
+
+// Mock that matches webpack resolver object.
+const mockResolver = {
+  plugin(name, callback) {
+    this.callback = callback;
+  },
+  simulate(req) {
+    this.callback.call(this, req, stub);
+  }
+};
+
+describe('webpack LocalModuleProxy', () => {
+  let proxy, spy;
+
+  beforeEach(() => {
+    spy = createSpy();
+    mockResolver.doResolve = spy;
+    proxy = new LocalModuleProxy({
+      moduleName: 'foo',
+      path: `${process.cwd()}/tmp/foo.js`
+    });
+  });
+  it('resolves a module request to another directory', () => {
+    proxy.apply(mockResolver);
+    mockResolver.simulate({path: 'myfile.js', request: 'foo', query: null, directory: false});
+    expect(spy).toHaveBeenCalledWith(['file'], {
+      path: 'myfile.js',
+      request: `${process.cwd()}/tmp/foo.js`,
+      query: null,
+      directory: false
+    }, stub);
+  });
+});

--- a/src/components/index.test.js
+++ b/src/components/index.test.js
@@ -10,8 +10,6 @@ function getFiles(path) {
   return fs.readdirSync(path).filter(d => !/^\.|index|example|test/.test(d));
 }
 
-debugger;
-
 describe('index', () => {
   it('should contain the components', () => {
     expect(WeaveComponents).toExist();


### PR DESCRIPTION
Implements #4.

The README contains instructions on how to implement in a test project.

* The resolver module is written in a very generic way, so it could be used for other stuff.
* Hot reloading should work. If you save a file the `ui-components` dir, webpack in the project consuming the lib should do a reload as if its in the same directory.