### PR TITLE
Switch to prop-types library

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "babel-preset-es2015": "6.18.0",
     "babel-preset-react": "6.16.0",
     "classnames": "^2.2.5",
-    "node-sass": "3.13.0"
+    "node-sass": "3.13.0",
+    "prop-types": "^15.5.8"
   },
   "devDependencies": {
     "babel-core": "6.18.2",

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * A button that will run a callback on click
@@ -41,20 +42,20 @@ Button.propTypes = {
   /**
  * Callback that will be run when the button is clicked.
  */
-  onClick: React.PropTypes.func,
+  onClick: PropTypes.func,
   /**
  * Text that will be used as the button label.
  * If this props is provided, it will be passed back to the `onClick` handler
  */
-  text: React.PropTypes.string,
+  text: PropTypes.string,
   /**
  * Disable the button.
  */
-  disabled: React.PropTypes.bool,
+  disabled: PropTypes.bool,
   /**
    * Render the button in $turquoise (useful for CTAs)
    */
-  primary: React.PropTypes.bool
+  primary: PropTypes.bool
 };
 
 Button.defaultProps = {

--- a/src/components/CircularProgress/CircularProgress.js
+++ b/src/components/CircularProgress/CircularProgress.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import React from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Size is set in px
@@ -34,7 +35,7 @@ CircularProgress.propTypes = {
   /**
   * Size of spinner in px
   */
-  size: React.PropTypes.number
+  size: PropTypes.number
 };
 
 CircularProgress.defaultProps = {

--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Button from '../Button';
 
@@ -87,27 +88,27 @@ Dialog.propTypes = {
   /**
    * Flag to show/hide the dialog
    */
-  active: React.PropTypes.bool,
+  active: PropTypes.bool,
   /**
    * An array of options that the user will be able to click.
    * Each item in the array will be rendered as a <Button /> in the dialog window.
    * Items can also be React elements.
    */
-  actions: React.PropTypes.array,
+  actions: PropTypes.array,
   /**
    * Callback that will be run when the dialog is closed
    */
-  onClose: React.PropTypes.func,
+  onClose: PropTypes.func,
   /**
    * Callback that runs when an action is clicked by the user. If the actions
    * If the `actions` prop is an array of strings,
    * this callback will return the action that was clicked.
    */
-  onActionClick: React.PropTypes.func,
+  onActionClick: PropTypes.func,
   /**
    * Toggles a modal overlay. If set to true, the overlay will appear,
    */
-  overlay: React.PropTypes.bool
+  overlay: PropTypes.bool
 };
 
 Dialog.defaultProps = {

--- a/src/components/Grid/GridColumn.js
+++ b/src/components/Grid/GridColumn.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * A child of the `<Grid />` component. Used for building layouts.
@@ -15,7 +16,7 @@ GridColumn.propTypes = {
   /**
    * The desired col-span; maximum of 12 columns
    */
-  span: React.PropTypes.number
+  span: PropTypes.number
 };
 
 export default GridColumn;

--- a/src/components/Grid/GridRow.js
+++ b/src/components/Grid/GridRow.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 /**
@@ -17,7 +18,7 @@ GridRow.propTypes = {
   /**
    * The direction in which to justify content. Should be 'left', 'center', or 'right';
   */
-  alignContent: React.PropTypes.string
+  alignContent: PropTypes.string
 };
 
 export default GridRow;

--- a/src/components/ListItem/ListItem.js
+++ b/src/components/ListItem/ListItem.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * A list item component that can be used for or showing off summary details about something!
@@ -57,12 +58,12 @@ class ListItem extends React.Component {
 
 
 ListItem.propTypes = {
-  active: React.PropTypes.bool,
-  text: React.PropTypes.any,
-  subText: React.PropTypes.any,
-  onClick: React.PropTypes.func,
-  style: React.PropTypes.object,
-  value: React.PropTypes.any
+  active: PropTypes.bool,
+  text: PropTypes.any,
+  subText: PropTypes.any,
+  onClick: PropTypes.func,
+  style: PropTypes.object,
+  value: PropTypes.any
 };
 
 

--- a/src/components/MatchedText/MatchedText.js
+++ b/src/components/MatchedText/MatchedText.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const TRUNCATE_CONTEXT = 6;
 const TRUNCATE_ELLIPSIS = '…';
@@ -118,13 +119,13 @@ MatchedText.propTypes = {
   /**
    * The base text to display
    */
-  text: React.PropTypes.string,
+  text: PropTypes.string,
   /**
    * {start: 3, length: 2} describes the area to highlight
    */
-  match: React.PropTypes.shape({
-    start: React.PropTypes.number,
-    length: React.PropTypes.number
+  match: PropTypes.shape({
+    start: PropTypes.number,
+    length: PropTypes.number
   }),
 };
 

--- a/src/components/Menu/MenuItem.js
+++ b/src/components/Menu/MenuItem.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 /**
@@ -36,11 +37,11 @@ MenuItem.propTypes = {
   /**
    * Handler that will be run on click. The `text` prop is passed to the handler function
    */
-  onClick: React.PropTypes.func,
+  onClick: PropTypes.func,
   /**
    * Text that will be displayed as the menu item.
    */
-  text: React.PropTypes.string
+  text: PropTypes.string
 };
 
 export default MenuItem;

--- a/src/components/WeaveCloudLogo/WeaveCloudLogo.js
+++ b/src/components/WeaveCloudLogo/WeaveCloudLogo.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import React from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * The Weaveworks 'Weavecloud' logo. The logo can be rendered using a 'dark' or 'light' argument
@@ -55,7 +56,7 @@ WeaveCloudLogo.propTypes = {
   /**
    * The color that the logo will be rendered in.
    */
-  theme: React.PropTypes.string
+  theme: PropTypes.string
 }
 
 WeaveCloudLogo.defaultProps = {


### PR DESCRIPTION
Since this repo is now used by Scope, we also have to transition to `prop-types` library here to get rid of deprecation errors in Scope: https://github.com/weaveworks/scope/issues/2496
