### PR TITLE
[Dialog] Only map actions if they exist

### DIFF
--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -68,7 +68,7 @@ class Dialog extends React.Component {
             {children}
           </div>
           <div className="weave-dialog-actions">
-            {actions.map((Action, i) => {
+            {actions && actions.map((Action, i) => {
               if (React.isValidElement(Action)) {
                 return React.cloneElement(Action, { key: i });
               }


### PR DESCRIPTION
Only try to render actions if they exist. This makes the Dialog more flexible, as it can be used for any type of modal.