### PR TITLE
Add earliest timestamp to time travel

### DIFF
--- a/src/components/TimeTravel/TimeTravel.js
+++ b/src/components/TimeTravel/TimeTravel.js
@@ -12,19 +12,20 @@ import { strongSpring } from '../../utils/animation';
 import { zoomFactor } from '../../utils/zooming';
 import {
   nowInSecondsPrecision,
+  clampDuration,
   scaleDuration,
 } from '../../utils/time';
 import {
   getTimeScale,
   findOptimalDurationFit,
   timestampToInputValue,
+  initialDurationPerTimelinePx,
+  minDurationPerTimelinePx,
+  maxDurationPerTimelinePx,
 } from '../../utils/timeline';
 
 import {
   TIMELINE_HEIGHT,
-  MIN_DURATION_PER_PX,
-  INIT_DURATION_PER_PX,
-  MAX_DURATION_PER_PX,
   MIN_TICK_SPACING_PX,
   MAX_TICK_SPACING_PX,
   FADE_OUT_FACTOR,
@@ -232,7 +233,7 @@ class TimeTravel extends React.Component {
       timestampNow: nowInSecondsPrecision(),
       focusedTimestamp: nowInSecondsPrecision(),
       inputValue: timestampToInputValue(props.timestamp),
-      durationPerPixel: INIT_DURATION_PER_PX,
+      durationPerPixel: initialDurationPerTimelinePx(props.earliestTimestamp),
       boundingRect: { width: 0, height: 0 },
       isPanning: false,
     };
@@ -357,9 +358,10 @@ class TimeTravel extends React.Component {
   }
 
   handleZoom(ev) {
+    const minDuration = minDurationPerTimelinePx(this.props.earliestTimestamp);
+    const maxDuration = maxDurationPerTimelinePx(this.props.earliestTimestamp);
     let durationPerPixel = scaleDuration(this.state.durationPerPixel, 1 / zoomFactor(ev));
-    if (durationPerPixel > MAX_DURATION_PER_PX) durationPerPixel = MAX_DURATION_PER_PX;
-    if (durationPerPixel < MIN_DURATION_PER_PX) durationPerPixel = MIN_DURATION_PER_PX;
+    durationPerPixel = clampDuration(durationPerPixel, [minDuration, maxDuration]);
 
     this.setState({ durationPerPixel });
     this.debouncedTrackZoom();

--- a/src/components/TimeTravel/TimeTravel.js
+++ b/src/components/TimeTravel/TimeTravel.js
@@ -12,7 +12,6 @@ import { strongSpring } from '../../utils/animation';
 import { zoomFactor } from '../../utils/zooming';
 import {
   nowInSecondsPrecision,
-  clampToNowInSecondsPrecision,
   scaleDuration,
 } from '../../utils/time';
 import {
@@ -169,7 +168,7 @@ const TimestampInput = styled.input`
  * A visual component used for time travelling between different states in the system.
  *
  * To make it behave correctly, it requires a `timestamp` (can initially be `null`)
- * which gets updated with `onChange`.
+ * which gets updated with `onChangeTimestamp`.
  *
  * ```javascript
  *  import React from 'react';
@@ -213,7 +212,7 @@ const TimestampInput = styled.input`
  *      return (
  *        <TimeTravel
  *          timestamp={this.state.timestamp}
- *          onChange={this.handleChange}
+ *          onChangeTimestamp={this.handleChange}
  *          onTimestampInputEdit={this.handleTimestampInputEdit}
  *          onTimestampLabelClick={this.handleTimestampLabelClick}
  *          onTimelineZoom={this.handleTimelineZoom}
@@ -304,6 +303,14 @@ class TimeTravel extends React.Component {
     }
   }
 
+  clampedTimestamp(timestamp) {
+    const startTimestamp = this.props.earliestTimestamp;
+    const endTimestamp = this.state.timestampNow;
+    if (timestamp.isBefore(startTimestamp)) timestamp = startTimestamp;
+    if (timestamp.isAfter(endTimestamp)) timestamp = endTimestamp;
+    return timestamp;
+  }
+
   handleResize() {
     // Update the timeline dimension information.
     this.setState({ boundingRect: this.svgRef.getBoundingClientRect() });
@@ -314,7 +321,7 @@ class TimeTravel extends React.Component {
     this.setState({ inputValue: ev.target.value });
 
     if (timestamp.isValid()) {
-      const clampedTimestamp = clampToNowInSecondsPrecision(timestamp);
+      const clampedTimestamp = this.clampedTimestamp(timestamp);
       this.instantUpdateTimestamp(clampedTimestamp, this.props.onTimestampInputEdit);
     }
   }
@@ -344,7 +351,7 @@ class TimeTravel extends React.Component {
   handlePan() {
     const dragDuration = scaleDuration(this.state.durationPerPixel, -d3Event.dx);
     const timestamp = moment(this.state.focusedTimestamp).add(dragDuration);
-    const focusedTimestamp = clampToNowInSecondsPrecision(timestamp);
+    const focusedTimestamp = this.clampedTimestamp(timestamp);
     this.handleTimelinePan(focusedTimestamp);
     this.setState({ focusedTimestamp });
   }
@@ -363,7 +370,7 @@ class TimeTravel extends React.Component {
     if (!timestamp.isSame(this.props.timestamp)) {
       this.setState({ inputValue: timestampToInputValue(timestamp) });
       this.debouncedUpdateTimestamp.cancel();
-      this.props.onChange(moment(timestamp));
+      this.props.onChangeTimestamp(moment(timestamp));
 
       // Used for tracking.
       if (callback) callback();
@@ -384,7 +391,7 @@ class TimeTravel extends React.Component {
   }
 
   jumpTo(timestamp) {
-    const focusedTimestamp = clampToNowInSecondsPrecision(timestamp);
+    const focusedTimestamp = this.clampedTimestamp(timestamp);
     this.handleInstantJump(focusedTimestamp);
     this.setState({ focusedTimestamp });
   }
@@ -485,9 +492,11 @@ class TimeTravel extends React.Component {
   }
 
   renderTimestampTick({ timestamp, position, isBehind }, periodFormat, opacity) {
-    // Ticks are disabled if they are in the future or if they are too transparent.
-    const disabled = timestamp.isAfter(this.state.timestampNow) || opacity < 0.4;
     const handleClick = () => this.jumpTo(timestamp);
+    const disabled = (opacity < 0.4
+      || timestamp.isAfter(this.state.timestampNow)
+      || timestamp.isBefore(this.props.earliestTimestamp)
+    );
 
     return (
       <g transform={`translate(${position}, 0)`} key={timestamp.format()}>
@@ -523,13 +532,16 @@ class TimeTravel extends React.Component {
     );
   }
 
-  renderDisabledShadow(timelineTransform) {
-    const timeScale = getTimeScale(timelineTransform);
-    const nowShift = timeScale(this.state.timestampNow);
+  renderDisabledShadow(timelineTransform, [startTimestamp, endTimestamp]) {
     const { width, height } = this.state.boundingRect;
 
+    const timeScale = getTimeScale(timelineTransform);
+    const startShift = startTimestamp ? timeScale(startTimestamp) : -width;
+    const endShift = endTimestamp ? timeScale(endTimestamp) : width;
+    const length = Math.max(0, endShift - startShift);
+
     return (
-      <DisabledRange transform={`translate(${nowShift}, 0)`} width={width} height={height} />
+      <DisabledRange transform={`translate(${startShift}, 0)`} width={length} height={height} />
     );
   }
 
@@ -545,7 +557,8 @@ class TimeTravel extends React.Component {
           height={height}
           fillOpacity={0}
         />
-        {this.renderDisabledShadow(timelineTransform)}
+        {this.renderDisabledShadow(timelineTransform, [null, this.props.earliestTimestamp])}
+        {this.renderDisabledShadow(timelineTransform, [this.state.timestampNow, null])}
         <g className="ticks" transform="translate(0, 1)">
           {this.renderPeriodTicks('year', timelineTransform)}
           {this.renderPeriodTicks('month', timelineTransform)}
@@ -615,9 +628,13 @@ TimeTravel.propTypes = {
    */
   timestamp: PropTypes.instanceOf(moment),
   /**
+   * The earliest timestamp we can travel back in time (moment.js object)
+   */
+  earliestTimestamp: PropTypes.instanceOf(moment),
+  /**
    * Required callback handling every timestamp change
    */
-  onChange: PropTypes.func.isRequired,
+  onChangeTimestamp: PropTypes.func.isRequired,
   /**
    * Optional callback handling timestamp change by direct input box editing (e.g. for tracking)
    */
@@ -639,6 +656,7 @@ TimeTravel.propTypes = {
 TimeTravel.defaultProps = {
   visible: true,
   timestamp: moment(),
+  earliestTimestamp: moment('2014-01-01T00:00:00Z'),
 };
 
 export default TimeTravel;

--- a/src/components/TimeTravel/example.js
+++ b/src/components/TimeTravel/example.js
@@ -3,6 +3,7 @@ import moment from 'moment';
 
 import TimeTravel from '.';
 
+
 export default class TimeTravelExample extends React.Component {
   constructor() {
     super();
@@ -11,10 +12,10 @@ export default class TimeTravelExample extends React.Component {
       timestamp: moment(),
     };
 
-    this.handleChange = this.handleChange.bind(this);
+    this.handleChangeTimestamp = this.handleChangeTimestamp.bind(this);
   }
 
-  handleChange(timestamp) {
+  handleChangeTimestamp(timestamp) {
     this.setState({ timestamp });
   }
 
@@ -22,7 +23,7 @@ export default class TimeTravelExample extends React.Component {
     return (
       <TimeTravel
         timestamp={this.state.timestamp}
-        onChange={this.handleChange}
+        onChangeTimestamp={this.handleChangeTimestamp}
       />
     );
   }

--- a/src/constants/timeline.js
+++ b/src/constants/timeline.js
@@ -2,9 +2,6 @@ import moment from 'moment';
 
 
 export const TIMELINE_HEIGHT = '55px';
-export const MIN_DURATION_PER_PX = moment.duration(250, 'milliseconds');
-export const INIT_DURATION_PER_PX = moment.duration(1, 'minute');
-export const MAX_DURATION_PER_PX = moment.duration(3, 'days');
 export const MIN_TICK_SPACING_PX = 70;
 export const MAX_TICK_SPACING_PX = 415;
 export const FADE_OUT_FACTOR = 1.4;

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -5,11 +5,6 @@ export function nowInSecondsPrecision() {
   return moment().startOf('second');
 }
 
-export function clampToNowInSecondsPrecision(timestamp) {
-  const now = nowInSecondsPrecision();
-  return timestamp.isAfter(now) ? now : timestamp;
-}
-
 // This is unfortunately not there in moment.js
 export function scaleDuration(duration, scale) {
   return moment.duration(duration.asMilliseconds() * scale);

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -9,3 +9,14 @@ export function nowInSecondsPrecision() {
 export function scaleDuration(duration, scale) {
   return moment.duration(duration.asMilliseconds() * scale);
 }
+
+export function clampDuration(duration, [minDuration, maxDuration]) {
+  let durationMs = duration.asMilliseconds();
+  if (minDuration && minDuration.asMilliseconds() > durationMs) {
+    durationMs = minDuration.asMilliseconds();
+  }
+  if (maxDuration && maxDuration.asMilliseconds() < durationMs) {
+    durationMs = maxDuration.asMilliseconds();
+  }
+  return moment.duration(durationMs);
+}

--- a/src/utils/timeline.js
+++ b/src/utils/timeline.js
@@ -2,10 +2,36 @@ import moment from 'moment';
 import { find } from 'lodash';
 
 import { scaleUtc } from 'd3-scale';
-import { scaleDuration } from './time';
+import { scaleDuration, clampDuration, nowInSecondsPrecision } from './time';
 
 import { MIN_TICK_SPACING_PX } from '../constants/timeline';
 
+
+function availableTimelineDuration(earliestTimestamp) {
+  return moment.duration(nowInSecondsPrecision().diff(earliestTimestamp));
+}
+
+// The most granular zoom is 4px per second, probably we don't want any more granular than that.
+export function minDurationPerTimelinePx() {
+  return moment.duration(250, 'milliseconds');
+}
+
+// Maximum level we can zoom out is such that the available range takes 400px. The 3 days
+// per pixel upper bound on that scale is to prevent ugly rendering in extreme cases.
+export function maxDurationPerTimelinePx(earliestTimestamp) {
+  const duration = scaleDuration(availableTimelineDuration(earliestTimestamp), 1 / 400);
+  const clampInterval = [minDurationPerTimelinePx(), moment.duration(3, 'days')];
+  return clampDuration(duration, clampInterval);
+}
+
+// The initial zoom level is set to be 10% of the max zoom out level capped at 1px per minute,
+// with the assumption that if we have a long recorded history, we're in most cases by
+// default going to be interested in what happened in last couple of hours or so.
+export function initialDurationPerTimelinePx(earliestTimestamp) {
+  const duration = scaleDuration(maxDurationPerTimelinePx(earliestTimestamp), 1 / 10);
+  const clampInterval = [minDurationPerTimelinePx(), moment.duration(1, 'minute')];
+  return clampDuration(duration, clampInterval);
+}
 
 export function getTimeScale({ focusedTimestamp, durationPerPixel }) {
   const roundedTimestamp = moment(focusedTimestamp).utc().startOf('second');


### PR DESCRIPTION
Add support to _beginning of time_, i.e. the earliest timestamp we can jump to in Time Travel as required by https://github.com/weaveworks/scope/issues/2887.

##### Notes

* The new `earliestTimestamp` fields defaults to beginning of year 2014 if no value is provided.
* `onChange` callback has been renamed to `onChangeTimestamp`, so that needs to be updated in Scope when bumping the dep to `ui-components`.
