### PR TITLE
Fix default value of LogoProgress `size` property

### DIFF
--- a/src/components/LogoProgress/LogoProgress.js
+++ b/src/components/LogoProgress/LogoProgress.js
@@ -14,7 +14,7 @@ import React from 'react';
  */
 class LogoProgress extends React.Component {
   render() {
-    const {size} = 150;
+    const {size = 150} = this.props;
     const styles = {
       width: size,
       height: size


### PR DESCRIPTION
`size` has always been `undefined`.

Backwards compatibility: all _our_ uses have either put this into a wrapper of `width: 150px` or then assigned `display: inline-block`. This PR won't change the rendering of these cases.