### PR TITLE
Make Time Travel support ranges and live mode

### DIFF
--- a/src/components/TimeTravel/RangeSelector.js
+++ b/src/components/TimeTravel/RangeSelector.js
@@ -1,0 +1,143 @@
+import React from 'react';
+import moment from 'moment';
+import styled from 'styled-components';
+
+
+const HEIGHT = '27px';
+
+const RangeSelectorWrapper = styled.div`
+  border-left: 1px solid ${props => props.theme.colors.neutral.lightgray};
+  min-width: 75px;
+`;
+
+const SelectedRangeWrapper = styled.div`
+  background-color: transparent;
+  cursor: pointer;
+  font-family: "Roboto", sans-serif;
+  font-size: 1rem;
+  padding: 3px 8px;
+  display: flex;
+  justify-content: space-between;
+  line-height: 21px;
+`;
+
+const SelectedRange = styled.div`
+  color: ${props => props.theme.colors.primary.charcoal};
+`;
+
+const RangeOptionsListWrapper = styled.div`
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  z-index: 3000;
+`;
+
+const RangeOptionsList = styled.div`
+  background-color: ${props => props.theme.colors.neutral.white};
+  border: 1px solid ${props => props.theme.colors.neutral.lightgray};
+  color: ${props => props.theme.colors.primary.charcoal};
+  box-sizing: border-box;
+  position: absolute;
+  text-align: left;
+`;
+
+const CaretIconsContainer = styled.span`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin-left: 8px;
+
+  .fa {
+    font-size: 75%;
+    line-height: 7px;
+  }
+`;
+
+const RangeOption = styled.div`
+  line-height: ${HEIGHT};
+  cursor: pointer;
+  padding: 0 8px;
+
+  &:hover {
+    background-color: ${props => props.theme.colors.lightgray};
+  }
+
+  ${props => props.selected && `
+    color: ${props.theme.colors.accent.blue};
+  `}
+`;
+
+const rangeOptions = [
+  { label: '15min', valueMs: moment.duration(15, 'minutes').asMilliseconds() },
+  { label: '30min', valueMs: moment.duration(30, 'minutes').asMilliseconds() },
+  { label: '1h', valueMs: moment.duration(1, 'hour').asMilliseconds() },
+  { label: '3h', valueMs: moment.duration(3, 'hours').asMilliseconds() },
+  { label: '6h', valueMs: moment.duration(6, 'hours').asMilliseconds() },
+  { label: '24h', valueMs: moment.duration(24, 'hours').asMilliseconds() },
+];
+
+export default class RangeSelector extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+
+    this.state = {
+      isOpen: false,
+    };
+
+    this.saveNodeRef = this.saveNodeRef.bind(this);
+    this.handleDropDownClick = this.handleDropDownClick.bind(this);
+    this.handleBackgroundClick = this.handleBackgroundClick.bind(this);
+  }
+
+  handleDropDownClick() {
+    this.setState({ isOpen: true });
+  }
+
+  handleBackgroundClick() {
+    this.setState({ isOpen: false });
+  }
+
+  saveNodeRef(ref) {
+    this.containerRef = ref;
+  }
+
+  render() {
+    const { rangeMs } = this.props;
+    const { isOpen } = this.state;
+
+    const selectedRangeLabel = rangeOptions.find(r => r.valueMs === rangeMs).label;
+    const anchorEl = this.containerRef && this.containerRef.getBoundingClientRect();
+    const menuStyle = anchorEl ? {
+      top: anchorEl.top - 1,
+      left: anchorEl.right - anchorEl.width,
+      minWidth: anchorEl.width + 1,
+    } : {};
+
+    return (
+      <RangeSelectorWrapper innerRef={this.saveNodeRef}>
+        <SelectedRangeWrapper onClick={this.handleDropDownClick}>
+          <SelectedRange>{selectedRangeLabel}</SelectedRange>
+          <CaretIconsContainer>
+            <span className="fa fa-caret-up" />
+            <span className="fa fa-caret-down" />
+          </CaretIconsContainer>
+        </SelectedRangeWrapper>
+        {isOpen && <RangeOptionsListWrapper onClick={this.handleBackgroundClick}>
+          <RangeOptionsList style={menuStyle}>
+            {rangeOptions.map(({ valueMs, label }) => (
+              <RangeOption
+                key={valueMs}
+                selected={valueMs === rangeMs}
+                onClick={() => this.props.onChange(valueMs)}
+              >
+                {label}
+              </RangeOption>
+            ))}
+          </RangeOptionsList>
+        </RangeOptionsListWrapper>}
+      </RangeSelectorWrapper>
+    );
+  }
+}

--- a/src/components/TimeTravel/TimeTravel.js
+++ b/src/components/TimeTravel/TimeTravel.js
@@ -212,6 +212,10 @@ const TimeControlsContainer = styled.div`
  * To make it behave correctly, it requires a `timestamp` (can initially be `null`)
  * which gets updated with `onChangeTimestamp`.
  *
+ * Optional features include:
+ *   * Auto-update live mode on top of the default paused mode
+ *   * Range selection instead of the default point-in-time selection
+ *
  * ```javascript
  *  import React from 'react';
  *  import moment from 'moment';
@@ -313,7 +317,7 @@ class TimeTravel extends React.Component {
     window.addEventListener('resize', this.handleResize);
     this.handleResize();
 
-    this.svg = select('.time-travel-timeline svg');
+    this.svg = select(this.svgRef);
     this.drag = drag()
       .on('start', this.handleTimelinePanStart)
       .on('end', this.handleTimelinePanEnd)
@@ -658,7 +662,7 @@ class TimeTravel extends React.Component {
     const startTimestamp = moment(focusedTimestamp).subtract(rangeMs).utc().format();
 
     return (
-      <g id="axis">
+      <g className="axis">
         <rect
           className="tooltip-container"
           transform={`translate(${-width / 2}, 0)`}
@@ -792,11 +796,11 @@ TimeTravel.propTypes = {
    */
   onChangeLiveMode: PropTypes.func,
   /**
-   * Optional range selector
+   * Adds a range selector to the timestamp selector, for when the timestamp info is not enough
    */
   hasRangeSelector: PropTypes.bool,
   /**
-   * Duration in milliseconds of the observed interval (which ends at `timestamp`)
+   * Duration in milliseconds of the focused range (which ends at `timestamp`)
    */
   rangeMs: PropTypes.number,
   /**

--- a/src/components/TimeTravel/TimeTravel.js
+++ b/src/components/TimeTravel/TimeTravel.js
@@ -35,18 +35,24 @@ import {
 } from '../../constants/timer';
 
 
+const rangeSelectorOptions = [
+  { label: '15min', valueMs: moment.duration(15, 'minutes').asMilliseconds() },
+  { label: '30min', valueMs: moment.duration(30, 'minutes').asMilliseconds() },
+  { label: '1h', valueMs: moment.duration(1, 'hour').asMilliseconds() },
+  { label: '3h', valueMs: moment.duration(3, 'hours').asMilliseconds() },
+  { label: '6h', valueMs: moment.duration(6, 'hours').asMilliseconds() },
+  { label: '24h', valueMs: moment.duration(24, 'hours').asMilliseconds() },
+];
+
 const TimeTravelContainer = styled.div`
   transition: all .15s ease-in-out;
   position: relative;
-  margin-bottom: 15px;
   overflow: hidden;
-  z-index: 2001;
+  z-index: 1;
   height: 0;
 
   ${props => props.visible && `
-    height: calc(${TIMELINE_HEIGHT} + 35px);
-    margin-bottom: 15px;
-    margin-top: -5px;
+    height: calc(${TIMELINE_HEIGHT} + 38px);
   `}
 `;
 
@@ -76,6 +82,7 @@ const TimelineContainer = styled.div`
     background-color: ${props => props.theme.colors.accent.orange};
     box-sizing: border-box;
     content: '';
+    pointer-events: none;
     position: absolute;
     display: block;
     left: 50%;
@@ -104,9 +111,14 @@ const Timeline = FullyPannableCanvas.extend`
   margin: 0 7px;
 `;
 
-const DisabledRange = styled.rect`
+const DisabledRangeShadow = styled.rect`
   fill: ${props => props.theme.colors.gray};
   fill-opacity: 0.15;
+`;
+
+const SelectedRangeShadow = styled.rect`
+  fill: ${props => props.theme.colors.accent.blue};
+  fill-opacity: 0.1;
 `;
 
 const ShallowButton = styled.button`
@@ -137,26 +149,87 @@ const TimelinePanButton = ShallowButton.extend`
   padding: 2px;
 `;
 
-const TimestampContainer = styled.div`
-  background-color: ${props => props.theme.colors.white};
-  border: 1px solid ${props => props.theme.colors.gray};
-  border-radius: 4px;
-  padding: 2px 8px;
+const TimelineStatus = styled.button`
+  border: 0;
+  background-color: transparent;
+  border-right: 1px solid ${props => props.theme.colors.neutral.lightgray};
+  color: ${props => props.theme.colors.primary.charcoal};
+  font-family: "Roboto", sans-serif;
+  font-size: 1rem;
+  padding: 3px 8px;
   pointer-events: all;
-  margin: 8px 0 25px 50%;
-  transform: translateX(-50%);
-  opacity: 0.8;
   display: inline-block;
+  text-align: center;
+  min-width: 80px;
+  outline: 0;
+  cursor: pointer;
+
+  // Remove outline on Firefox
+  &::-moz-focus-inner {
+    border: 0;
+  }
+
+  @keyframes blinker {
+    50% { opacity: 0.5; }
+  }
+
+  ${props => props.selected && `
+    animation: blinker 1.5s linear infinite;
+    background-color: rgba(143, 143, 215, 0.15);
+  `}
+`;
+
+const TimestampContainer = styled.div`
+  font-size: 13px;
+  align-items: baseline;
+  padding: 3px 8px;
+  pointer-events: all;
+  opacity: 0.8;
+  display: flex;
 `;
 
 const TimestampInput = styled.input`
   background-color: transparent;
   font-family: "Roboto", sans-serif;
+  margin-right: 3px;
   text-align: center;
   font-size: 1rem;
   width: 165px;
   border: 0;
   outline: 0;
+`;
+
+const RangeSelector = styled.select`
+  border: 0;
+  border-left: 1px solid ${props => props.theme.colors.neutral.lightgray};
+  color: ${props => props.theme.colors.primary.charcoal};
+  background-color: transparent;
+  cursor: pointer;
+  font-family: "Roboto", sans-serif;
+  font-size: 1rem;
+  margin-right: 5px;
+  text-align: center;
+  text-align-last: center;
+  outline: 0;
+  padding: 3px;
+
+  // Remove outline on Firefox
+  &::-moz-focus-inner {
+    border: 0;
+  }
+`;
+
+const TimeControlsWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  margin: 8px 0 25px;
+`;
+
+const TimeControlsContainer = styled.div`
+  border: 1px solid ${props => props.theme.colors.neutral.lightgray};
+  background-color: ${props => props.theme.colors.white};
+  border-radius: 5px;
+  display: flex;
 `;
 
 
@@ -225,37 +298,40 @@ class TimeTravel extends React.Component {
     super(props, context);
 
     this.state = {
+      rangeMs: props.rangeMs,
       timestampNow: formattedTimestamp(),
       focusedTimestamp: formattedTimestamp(props.timestamp),
       inputTimestamp: formattedTimestamp(props.timestamp),
       durationMsPerPixel: initialDurationMsPerTimelinePx(props.earliestTimestamp),
       boundingRect: { width: 0, height: 0 },
+      showingLive: props.showingLive,
       isPanning: false,
     };
 
     this.jumpRelativePixels = this.jumpRelativePixels.bind(this);
-    this.jumpForward = this.jumpForward.bind(this);
-    this.jumpBackward = this.jumpBackward.bind(this);
+    this.handleJumpForward = this.handleJumpForward.bind(this);
+    this.handleJumpBackward = this.handleJumpBackward.bind(this);
     this.jumpTo = this.jumpTo.bind(this);
 
     this.handleZoom = this.handleZoom.bind(this);
-    this.handlePanStart = this.handlePanStart.bind(this);
-    this.handlePanEnd = this.handlePanEnd.bind(this);
-    this.handlePan = this.handlePan.bind(this);
+    this.handleTimelinePanStart = this.handleTimelinePanStart.bind(this);
+    this.handleTimelinePanEnd = this.handleTimelinePanEnd.bind(this);
+    this.handleTimelinePan = this.handleTimelinePan.bind(this);
 
     this.saveSvgRef = this.saveSvgRef.bind(this);
     this.debouncedTrackZoom = debounce(this.trackZoom.bind(this), ZOOM_TRACK_DEBOUNCE_INTERVAL);
 
     this.handleResize = debounce(this.handleResize.bind(this), 200);
+    this.handleRangeChange = this.handleRangeChange.bind(this);
     this.handleInputChange = this.handleInputChange.bind(this);
-    this.handleTimelinePan = this.handleTimelinePan.bind(this);
-    this.handleTimelinePanEnd = this.handleTimelinePanEnd.bind(this);
-    this.handleInstantJump = this.handleInstantJump.bind(this);
+
+    this.handleLiveModeToggle = this.handleLiveModeToggle.bind(this);
 
     this.setTimestampFromProps = this.setTimestampFromProps.bind(this);
     this.instantUpdateTimestamp = this.instantUpdateTimestamp.bind(this);
-    this.debouncedUpdateTimestamp = debounce(
-      this.instantUpdateTimestamp.bind(this),
+    this.instantTimestampUpdateCallbacks = this.instantTimestampUpdateCallbacks.bind(this);
+    this.debouncedTimestampUpdateCallbacks = debounce(
+      this.instantTimestampUpdateCallbacks.bind(this),
       TIMELINE_DEBOUNCE_INTERVAL
     );
   }
@@ -266,14 +342,19 @@ class TimeTravel extends React.Component {
 
     this.svg = select('.time-travel-timeline svg');
     this.drag = drag()
-      .on('start', this.handlePanStart)
-      .on('end', this.handlePanEnd)
-      .on('drag', this.handlePan);
+      .on('start', this.handleTimelinePanStart)
+      .on('end', this.handleTimelinePanEnd)
+      .on('drag', this.handleTimelinePan);
     this.svg.call(this.drag);
 
     // Force periodic updates of the availability range as time goes by.
     this.timer = setInterval(() => {
-      this.setState({ timestampNow: formattedTimestamp() });
+      const timestampNow = formattedTimestamp();
+      this.setState({ timestampNow });
+
+      if (this.state.hasLiveMode && this.state.showingLive) {
+        this.setTimestamp(timestampNow);
+      }
     }, TIMELINE_TICK_INTERVAL);
   }
 
@@ -283,6 +364,7 @@ class TimeTravel extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     this.setTimestampFromProps(nextProps);
+    this.setState({ rangeMs: nextProps.rangeMs });
   }
 
   componentWillUnmount() {
@@ -292,10 +374,12 @@ class TimeTravel extends React.Component {
   }
 
   setTimestampFromProps({ timestamp }) {
-    this.setState({ inputTimestamp: formattedTimestamp(timestamp) });
-    // Don't update the focused timestamp if we're not paused (so the timeline is hidden).
-    if (timestamp) {
-      this.setState({ focusedTimestamp: timestamp });
+    if (!this.state.hasLiveMode || !this.state.showingLive) {
+      this.setState({ inputTimestamp: formattedTimestamp(timestamp) });
+      // Don't update the focused timestamp if we're not paused (so the timeline is hidden).
+      if (timestamp) {
+        this.setState({ focusedTimestamp: timestamp });
+      }
     }
   }
 
@@ -312,51 +396,69 @@ class TimeTravel extends React.Component {
     this.setState({ boundingRect: this.svgRef.getBoundingClientRect() });
   }
 
+  handleRangeChange(ev) {
+    const rangeMs = Number(ev.target.value);
+    this.props.onChangeRange(rangeMs);
+    this.setState({ rangeMs });
+
+    const minDurationMs = minDurationMsPerTimelinePx();
+    const maxDurationMs = maxDurationMsPerTimelinePx(this.props.earliestTimestamp, rangeMs);
+    let durationMsPerPixel = rangeMs / (this.state.boundingRect.width / 3);
+    durationMsPerPixel = clamp(durationMsPerPixel, minDurationMs, maxDurationMs);
+    this.setState({ durationMsPerPixel });
+  }
+
   handleInputChange(ev) {
     const inputTimestamp = ev.target.value;
     this.setState({ inputTimestamp });
 
     if (moment(inputTimestamp).isValid()) {
       const clampedTimestamp = this.clampedTimestamp(inputTimestamp);
-      this.instantUpdateTimestamp(clampedTimestamp, this.props.onTimestampInputEdit);
+      if (inputTimestamp !== this.state.inputTimestamp) {
+        this.instantUpdateTimestamp(clampedTimestamp, this.props.onTimestampInputEdit);
+      }
     }
   }
 
-  handleTimelinePan(timestamp) {
-    this.setState({ inputTimestamp: timestamp });
-    this.debouncedUpdateTimestamp(timestamp);
-  }
-
-  handleTimelinePanEnd(timestamp) {
-    this.instantUpdateTimestamp(timestamp, this.props.onTimelinePan);
-  }
-
-  handleInstantJump(timestamp) {
-    this.instantUpdateTimestamp(timestamp, this.props.onTimestampLabelClick);
-  }
-
-  handlePanStart() {
+  handleTimelinePanStart() {
     this.setState({ isPanning: true });
+    this.setLiveMode(false);
   }
 
-  handlePanEnd() {
-    this.handleTimelinePanEnd(this.state.focusedTimestamp);
+  handleTimelinePanEnd() {
     this.setState({ isPanning: false });
+
+    const momentFocusedTimestamp = moment(this.state.focusedTimestamp).utc();
+    const diffDurationMs = moment().utc().diff(momentFocusedTimestamp);
+    const pixelsToEndTime = diffDurationMs / this.state.durationMsPerPixel;
+
+    // TODO: Make right side of available interval sticky so that it automatically
+    // switches to live mode when dragged there.
+    if (pixelsToEndTime < 10 && this.props.hasLiveMode && !this.state.showingLive) {
+      this.setLiveMode(true);
+      this.instantUpdateTimestamp(this.state.timestampNow, this.props.onTimelinePan);
+    } else {
+      this.instantUpdateTimestamp(this.state.focusedTimestamp, this.props.onTimelinePan);
+    }
   }
 
-  handlePan() {
+  handleTimelinePan() {
     const dragDurationMs = -this.state.durationMsPerPixel * d3Event.dx;
     const momentTimestamp = moment(this.state.focusedTimestamp).add(dragDurationMs);
-    const focusedTimestamp = this.clampedTimestamp(formattedTimestamp(momentTimestamp));
-    this.handleTimelinePan(focusedTimestamp);
-    this.setState({ focusedTimestamp });
+    const timestamp = this.clampedTimestamp(formattedTimestamp(momentTimestamp));
+
+    this.setTimestamp(timestamp);
+    this.debouncedTimestampUpdateCallbacks(timestamp);
   }
 
   handleZoom(ev) {
-    const minDurationMs = minDurationMsPerTimelinePx(this.props.earliestTimestamp);
-    const maxDurationMs = maxDurationMsPerTimelinePx(this.props.earliestTimestamp);
+    const minDurationMs = minDurationMsPerTimelinePx();
+    const maxDurationMs = maxDurationMsPerTimelinePx(
+      this.props.earliestTimestamp,
+      this.state.rangeMs,
+    );
+
     let durationMsPerPixel = this.state.durationMsPerPixel / zoomFactor(ev);
-    // console.log(durationMsPerPixel, minDurationMs, maxDurationMs);
     durationMsPerPixel = clamp(durationMsPerPixel, minDurationMs, maxDurationMs);
 
     this.setState({ durationMsPerPixel });
@@ -364,14 +466,41 @@ class TimeTravel extends React.Component {
     ev.preventDefault();
   }
 
-  instantUpdateTimestamp(timestamp, callback) {
-    if (timestamp !== this.props.timestamp) {
-      this.setState({ inputTimestamp: timestamp });
-      this.debouncedUpdateTimestamp.cancel();
-      this.props.onChangeTimestamp(timestamp);
+  handleLiveModeToggle() {
+    const showingLive = !this.state.showingLive;
+    this.setLiveMode(showingLive);
+    if (showingLive) {
+      this.setTimestamp(this.state.timestampNow);
+    }
+  }
 
-      // Used for tracking.
-      if (callback) callback();
+  setTimestamp(timestamp) {
+    this.setState({
+      focusedTimestamp: timestamp,
+      inputTimestamp: timestamp,
+    });
+  }
+
+  instantTimestampUpdateCallbacks(timestamp, callback) {
+    // Used for tracking.
+    if (callback) callback();
+    this.props.onChangeTimestamp(timestamp);
+  }
+
+  instantUpdateTimestamp(timestamp, callback) {
+    if (timestamp !== this.state.focusedTimestamp) {
+      this.debouncedTimestampUpdateCallbacks.cancel();
+      this.instantTimestampUpdateCallbacks(timestamp, callback);
+      this.setTimestamp(timestamp);
+    }
+  }
+
+  setLiveMode(showingLive) {
+    if (showingLive !== this.state.showingLive) {
+      this.setState({ showingLive });
+      if (this.props.onChangeLiveMode) {
+        this.props.onChangeLiveMode(showingLive);
+      }
     }
   }
 
@@ -389,9 +518,8 @@ class TimeTravel extends React.Component {
   }
 
   jumpTo(timestamp) {
-    const focusedTimestamp = this.clampedTimestamp(timestamp);
-    this.handleInstantJump(focusedTimestamp);
-    this.setState({ focusedTimestamp });
+    this.setLiveMode(false);
+    this.instantUpdateTimestamp(this.clampedTimestamp(timestamp), this.props.onTimestampLabelClick);
   }
 
   jumpRelativePixels(pixels) {
@@ -400,11 +528,11 @@ class TimeTravel extends React.Component {
     this.jumpTo(formattedTimestamp(momentTimestamp));
   }
 
-  jumpForward() {
+  handleJumpForward() {
     this.jumpRelativePixels(this.state.boundingRect.width / 4);
   }
 
-  jumpBackward() {
+  handleJumpBackward() {
     this.jumpRelativePixels(-this.state.boundingRect.width / 4);
   }
 
@@ -533,7 +661,7 @@ class TimeTravel extends React.Component {
     );
   }
 
-  renderDisabledShadow(timelineTransform, startTimestamp, endTimestamp) {
+  renderRangeShadow(RangeShadow, timelineTransform, startTimestamp, endTimestamp) {
     const { width, height } = this.state.boundingRect;
 
     const timeScale = getTimeScale(timelineTransform);
@@ -542,12 +670,14 @@ class TimeTravel extends React.Component {
     const length = Math.max(0, endShift - startShift);
 
     return (
-      <DisabledRange transform={`translate(${startShift}, 0)`} width={length} height={height} />
+      <RangeShadow transform={`translate(${startShift}, 0)`} width={length} height={height} />
     );
   }
 
-  renderAxis(timelineTransform) {
+  renderAxis(transform) {
     const { width, height } = this.state.boundingRect;
+    const { focusedTimestamp, rangeMs } = transform;
+    const startTimestamp = moment(focusedTimestamp).subtract(rangeMs).utc().format();
 
     return (
       <g id="axis">
@@ -558,28 +688,35 @@ class TimeTravel extends React.Component {
           height={height}
           fillOpacity={0}
         />
-        {this.renderDisabledShadow(timelineTransform, null, this.props.earliestTimestamp)}
-        {this.renderDisabledShadow(timelineTransform, this.state.timestampNow, null)}
+
+        {this.renderRangeShadow(DisabledRangeShadow, transform, null, this.props.earliestTimestamp)}
+        {this.renderRangeShadow(DisabledRangeShadow, transform, this.state.timestampNow, null)}
+        {this.props.hasRangeSelector &&
+          this.renderRangeShadow(SelectedRangeShadow, transform, startTimestamp, focusedTimestamp)}
+
         <g className="ticks" transform="translate(0, 1)">
-          {this.renderPeriodTicks('year', timelineTransform)}
-          {this.renderPeriodTicks('month', timelineTransform)}
-          {this.renderPeriodTicks('day', timelineTransform)}
-          {this.renderPeriodTicks('minute', timelineTransform)}
+          {this.renderPeriodTicks('year', transform)}
+          {this.renderPeriodTicks('month', transform)}
+          {this.renderPeriodTicks('day', transform)}
+          {this.renderPeriodTicks('minute', transform)}
         </g>
       </g>
     );
   }
 
   renderAnimatedContent() {
+    const { focusedTimestamp, durationMsPerPixel, rangeMs } = this.state;
     return (
       <Motion
         style={{
-          focusedTimestampMs: strongSpring(moment(this.state.focusedTimestamp).valueOf()),
-          durationMsPerPixel: strongSpring(this.state.durationMsPerPixel),
+          focusedTimestampMs: strongSpring(moment(focusedTimestamp).valueOf()),
+          durationMsPerPixel: strongSpring(durationMsPerPixel),
+          rangeMs: strongSpring(rangeMs),
         }}>
         {interpolated => this.renderAxis({
           focusedTimestamp: formattedTimestamp(interpolated.focusedTimestampMs),
           durationMsPerPixel: interpolated.durationMsPerPixel,
+          rangeMs: interpolated.rangeMs,
         })}
       </Motion>
     );
@@ -592,7 +729,7 @@ class TimeTravel extends React.Component {
     return (
       <TimeTravelContainer className="time-travel" visible={this.props.visible}>
         <TimelineContainer className="time-travel-timeline">
-          <TimelinePanButton onClick={this.jumpBackward}>
+          <TimelinePanButton onClick={this.handleJumpBackward}>
             <span className="fa fa-chevron-left" />
           </TimelinePanButton>
           <Timeline panning={isPanning} innerRef={this.saveSvgRef} onWheel={this.handleZoom}>
@@ -601,16 +738,35 @@ class TimeTravel extends React.Component {
               {this.renderAnimatedContent()}
             </g>
           </Timeline>
-          <TimelinePanButton onClick={this.jumpForward}>
+          <TimelinePanButton onClick={this.handleJumpForward}>
             <span className="fa fa-chevron-right" />
           </TimelinePanButton>
         </TimelineContainer>
-        <TimestampContainer>
-          <TimestampInput
-            value={this.state.inputTimestamp}
-            onChange={this.handleInputChange}
-          /> UTC
-        </TimestampContainer>
+        <TimeControlsWrapper>
+          <TimeControlsContainer>
+            {this.props.hasLiveMode && <TimelineStatus
+              selected={!this.state.showingLive}
+              onClick={this.handleLiveModeToggle}
+            >
+              {this.state.showingLive ? 'Live' : 'Paused'}
+            </TimelineStatus>}
+            <TimestampContainer>
+              <TimestampInput
+                value={this.state.inputTimestamp}
+                onChange={this.handleInputChange}
+                disabled={this.state.hasLiveMode && this.state.showingLive}
+              /> UTC
+            </TimestampContainer>
+            {this.props.hasRangeSelector && <RangeSelector
+              value={this.state.rangeMs}
+              onChange={this.handleRangeChange}
+            >
+              {rangeSelectorOptions.map(({ valueMs, label }) => (
+                <option key={valueMs} value={valueMs}>{label}</option>
+              ))}
+            </RangeSelector>}
+          </TimeControlsContainer>
+        </TimeControlsWrapper>
       </TimeTravelContainer>
     );
   }
@@ -649,11 +805,39 @@ TimeTravel.propTypes = {
    * Optional callback handling timeline panning (e.g. for tracking)
    */
   onTimelinePan: PropTypes.func,
+  /**
+   * Enables Time Travel to be in the live auto-update mode
+   */
+  hasLiveMode: PropTypes.bool,
+  /**
+   * The live mode shows current time and ignores the `timestamp` param
+   */
+  showingLive: PropTypes.bool,
+  /**
+   * Optional callback handling the change of live mode
+   */
+  onChangeLiveMode: PropTypes.func,
+  /**
+   * Optional range selector
+   */
+  hasRangeSelector: PropTypes.bool,
+  /**
+   * Duration in milliseconds of the observed interval (which ends at `timestamp`)
+   */
+  rangeMs: PropTypes.number,
+  /**
+   * Optional callback handling range in milliseconds change
+   */
+  onChangeRange: PropTypes.func,
 };
 
 TimeTravel.defaultProps = {
   visible: true,
   earliestTimestamp: '2014-01-01T00:00:00Z',
+  hasLiveMode: false,
+  showingLive: true, // only relevant if live mode is enabled
+  hasRangeSelector: false,
+  rangeMs: 3600000, // 1 hour as a default, only relevant if range selector is enabled
 };
 
 export default TimeTravel;

--- a/src/components/TimeTravel/TimeTravel.js
+++ b/src/components/TimeTravel/TimeTravel.js
@@ -750,6 +750,8 @@ class TimeTravel extends React.Component {
   }
 }
 
+// TODO: Consider removing `showingLive` property. See the PR comment for details:
+// https://github.com/weaveworks/ui-components/pull/68#discussion_r152771727
 TimeTravel.propTypes = {
   /**
    * Shows Time Travel component

--- a/src/components/TimeTravel/example.js
+++ b/src/components/TimeTravel/example.js
@@ -1,30 +1,79 @@
 import React from 'react';
 import moment from 'moment';
+import styled from 'styled-components';
 
 import TimeTravel from '.';
 
+
+const Example = styled.div`
+  margin-bottom: 30px;
+`;
+
+const Info = styled.div`
+  color: #888;
+  font-size: 18px;
+  font-style: italic;
+  text-align: center;
+  margin-bottom: 13px;
+`;
 
 export default class TimeTravelExample extends React.Component {
   constructor() {
     super();
 
     this.state = {
-      timestamp: moment().format(),
+      timestamp1: moment().format(),
+      timestamp2: moment().format(),
+      showingLive2: true,
+      rangeMs2: 3600000,
     };
 
-    this.handleChangeTimestamp = this.handleChangeTimestamp.bind(this);
+    this.handleChangeTimestamp1 = this.handleChangeTimestamp1.bind(this);
+    this.handleChangeTimestamp2 = this.handleChangeTimestamp2.bind(this);
+    this.handleChangeLiveMode2 = this.handleChangeLiveMode2.bind(this);
+    this.handleChangeRange2 = this.handleChangeRange2.bind(this);
   }
 
-  handleChangeTimestamp(timestamp) {
-    this.setState({ timestamp });
+  handleChangeTimestamp1(timestamp1) {
+    this.setState({ timestamp1 });
+  }
+
+  handleChangeTimestamp2(timestamp2) {
+    this.setState({ timestamp2 });
+  }
+
+  handleChangeLiveMode2(showingLive2) {
+    this.setState({ showingLive2 });
+  }
+
+  handleChangeRange2(rangeMs2) {
+    this.setState({ rangeMs2 });
   }
 
   render() {
     return (
-      <TimeTravel
-        timestamp={this.state.timestamp}
-        onChangeTimestamp={this.handleChangeTimestamp}
-      />
+      <div>
+        <Example>
+          <Info>Simple timestamp selector</Info>
+          <TimeTravel
+            timestamp={this.state.timestamp1}
+            onChangeTimestamp={this.handleChangeTimestamp1}
+          />
+        </Example>
+        <Example>
+          <Info>Range selector with live mode support</Info>
+          <TimeTravel
+            timestamp={this.state.timestamp2}
+            onChangeTimestamp={this.handleChangeTimestamp2}
+            hasLiveMode
+            showingLive={this.state.showingLive2}
+            onChangeLiveMode={this.handleChangeLiveMode2}
+            hasRangeSelector
+            rangeMs={this.state.rangeMs2}
+            onChangeRange={this.handleChangeRange2}
+          />
+        </Example>
+      </div>
     );
   }
 }

--- a/src/components/index.test.js
+++ b/src/components/index.test.js
@@ -24,12 +24,7 @@ describe('index', () => {
   });
   it('should export all the components from "src/components"', () => {
     const componentsDir = './src/components';
-    const files = _(getFiles(componentsDir))
-      .map(d => getFiles(`${componentsDir}/${d}`))
-      .flatten()
-      .map(f => f.replace('.js', ''))
-      .filter(f => f !== '__snapshots__')
-      .value();
+    const files = getFiles(componentsDir);
     _.each(files, (f) => {
       expect(WeaveComponents[f]).toExist(
         `${f} module is missing. Did you export it from "src/components/index.js"?`

--- a/src/utils/timeline.js
+++ b/src/utils/timeline.js
@@ -16,9 +16,9 @@ function availableTimelineDurationMs(earliestTimestamp) {
   return currentMomentTimestamp.diff(earliestMomentTimestamp);
 }
 
-// The most granular zoom is 1px per second, probably we don't want any more granular than that.
+// The most granular zoom is 2px per second, probably we don't want any more granular than that.
 export function minDurationMsPerTimelinePx() {
-  return moment.duration(1, 'second').asMilliseconds();
+  return moment.duration(500, 'milliseconds').asMilliseconds();
 }
 
 // Maximum level we can zoom out is such that the available range takes 400px. The 3 days

--- a/src/utils/timeline.js
+++ b/src/utils/timeline.js
@@ -16,16 +16,22 @@ function availableTimelineDurationMs(earliestTimestamp) {
   return currentMomentTimestamp.diff(earliestMomentTimestamp);
 }
 
-// The most granular zoom is 4px per second, probably we don't want any more granular than that.
+// The most granular zoom is 1px per second, probably we don't want any more granular than that.
 export function minDurationMsPerTimelinePx() {
-  return moment.duration(250, 'milliseconds').asMilliseconds();
+  return moment.duration(1, 'second').asMilliseconds();
 }
 
 // Maximum level we can zoom out is such that the available range takes 400px. The 3 days
 // per pixel upper bound on that scale is to prevent ugly rendering in extreme cases.
-export function maxDurationMsPerTimelinePx(earliestTimestamp) {
+export function maxDurationMsPerTimelinePx(earliestTimestamp, rangeMs) {
   const durationMsLowerBound = minDurationMsPerTimelinePx();
-  const durationMsUpperBound = moment.duration(3, 'days').asMilliseconds();
+  let durationMsUpperBound = moment.duration(3, 'days').asMilliseconds();
+  if (rangeMs) {
+    // If a time range is shown on the timeline, allow only so much zooming
+    // out that at least 10px of that range is shown in the timeline.
+    durationMsUpperBound = Math.min(durationMsUpperBound, rangeMs / 10);
+  }
+
   const durationMs = availableTimelineDurationMs(earliestTimestamp) / 400.0;
   return clamp(durationMs, durationMsLowerBound, durationMsUpperBound);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5224,7 +5224,7 @@ querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
-raf@^3.1.0, raf@^3.3.2, raf@^3.4.0:
+raf@^3.1.0, raf@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
   dependencies:


### PR DESCRIPTION
Resolves #64.

![image](https://user-images.githubusercontent.com/1216874/33026339-8479de9c-ce10-11e7-9906-735bc4bba79a.png)

##### Changes

* Added an optional range selection feature to Time Travel component. Range selectors will be used in _Monitor_ part but not in _Explore_.
* Added an optional live/paused mode toggle to support the default auto-update mode in the dashboard charts.
* Reduced maximum timeline zoom level 2x.

##### TODO

* See if we settle at the current range intervals: `15min`, `30min`, `1h`, `3h`, `6h`, `24h`
* Consider alternative wording to _live_ / _paused_ states (and perhaps tweak the styling around it)
* Sticky switching to live mode should also work when pressing the right arrow on timeline
* Time Travel component is becoming too massive (> 800 lines atm). We should distribute its logic between various subcomponents (_RangeSelector_ already exists, we could make _TimestampInput_, _TimeTravelStatus_, _Timeline_, _TimelineMarkers_ etc.. separate components).

**Note to reviewer:** Test with UI proxying from https://github.com/weaveworks/service-ui/pull/1447
