### PR TITLE
Use normalize.css and fix button sizes

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { ThemeProvider } from 'styled-components';
+import { ThemeProvider, injectGlobal } from 'styled-components';
+import styledNormalize from 'styled-normalize';
 
 import 'font-awesome-webpack';
 
@@ -12,6 +13,19 @@ import Root from './Root';
 
 import '../css/demo.scss';
 import '../img/favicon.ico';
+
+(() => injectGlobal`
+  ${styledNormalize}
+
+  /* https://github.com/necolas/normalize.css/issues/694 */
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    font-family: inherit;
+  }
+`)();
 
 ReactDOM.render(
   <ThemeProvider theme={theme}>

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "node-sass": "4.5.3",
     "polished": "^1.7.0",
     "prop-types": "^15.5.8",
-    "react-motion": "0.5.2"
+    "react-motion": "0.5.2",
+    "styled-normalize": "^2.2.1"
   },
   "devDependencies": {
     "babel-core": "6.18.2",

--- a/src/components/TimeTravel/TimeTravel.js
+++ b/src/components/TimeTravel/TimeTravel.js
@@ -128,6 +128,7 @@ const ShallowButton = styled.button`
 `;
 
 const TimestampLabel = ShallowButton.extend`
+  font-size: 13px;
   margin-left: 2px;
   padding: 3px;
 
@@ -138,6 +139,7 @@ const TimestampLabel = ShallowButton.extend`
 `;
 
 const TimelinePanButton = ShallowButton.extend`
+  font-size: 13px;
   pointer-events: all;
   padding: 2px;
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6057,6 +6057,10 @@ styled-components@2.2.1:
     stylis "^3.2.1"
     supports-color "^3.2.3"
 
+styled-normalize@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/styled-normalize/-/styled-normalize-2.2.1.tgz#c93a007c0339a69e3254eeef8cb6a5a96e5ca4eb"
+
 stylis@^3.2.1:
   version "3.2.15"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.2.15.tgz#1800f829fdf3cf0d647ae6cdb5fb70a1fd81c3e2"


### PR DESCRIPTION
Add normalize to the component viewer with a font-family workaround which we are using in `service-ui`.

Fixed some button sizes which appear different on OSX and Chrome (corrected by normalize.css).