### PR TITLE
Remove min-zoom constraint for Time Travel ranges

### DIFF
--- a/src/constants/timeline.js
+++ b/src/constants/timeline.js
@@ -7,6 +7,7 @@ export const MAX_TICK_SPACING_PX = 415;
 export const FADE_OUT_FACTOR = 1.4;
 export const TICKS_ROW_SPACING = 16;
 export const MAX_TICK_ROWS = 3;
+export const MIN_RANGE_INTERVAL_PX = 6;
 
 export const TICK_SETTINGS_PER_PERIOD = {
   year: {

--- a/src/utils/timeline.js
+++ b/src/utils/timeline.js
@@ -23,15 +23,9 @@ export function minDurationMsPerTimelinePx() {
 
 // Maximum level we can zoom out is such that the available range takes 400px. The 3 days
 // per pixel upper bound on that scale is to prevent ugly rendering in extreme cases.
-export function maxDurationMsPerTimelinePx(earliestTimestamp, rangeMs) {
+export function maxDurationMsPerTimelinePx(earliestTimestamp) {
   const durationMsLowerBound = minDurationMsPerTimelinePx();
-  let durationMsUpperBound = moment.duration(3, 'days').asMilliseconds();
-  if (rangeMs) {
-    // If a time range is shown on the timeline, allow only so much zooming
-    // out that at least 10px of that range is shown in the timeline.
-    durationMsUpperBound = Math.min(durationMsUpperBound, rangeMs / 10);
-  }
-
+  const durationMsUpperBound = moment.duration(3, 'days').asMilliseconds();
   const durationMs = availableTimelineDurationMs(earliestTimestamp) / 400.0;
   return clamp(durationMs, durationMsLowerBound, durationMsUpperBound);
 }


### PR DESCRIPTION
Resolves #75.

##### Changes

* Removed zoom limit that depended on the selected range, making zoom min-zoom a constant again.
* Introduced a minimum width for the rendered intervals in Time Travel timeline to make selected range always visible.
