### PR TITLE
Iterate through Time Travel time periods correctly

### DIFF
--- a/src/constants/timeline.js
+++ b/src/constants/timeline.js
@@ -1,5 +1,3 @@
-import moment from 'moment';
-
 
 export const TIMELINE_HEIGHT = '55px';
 export const MIN_TICK_SPACING_PX = 70;
@@ -13,38 +11,23 @@ export const TICK_SETTINGS_PER_PERIOD = {
   year: {
     format: 'YYYY',
     childPeriod: 'month',
-    intervalsMs: [
-      moment.duration(1, 'year').asMilliseconds(),
-    ],
+    periodIntervals: [1], // 1 year
   },
   month: {
     format: 'MMMM',
     parentPeriod: 'year',
     childPeriod: 'day',
-    intervalsMs: [
-      moment.duration(1, 'month').asMilliseconds(),
-      moment.duration(3, 'months').asMilliseconds(),
-    ],
+    periodIntervals: [1, 3], // 1 month, 1 quarter
   },
   day: {
     format: 'Do',
     parentPeriod: 'month',
     childPeriod: 'minute',
-    intervalsMs: [
-      moment.duration(1, 'day').asMilliseconds(),
-      moment.duration(1, 'week').asMilliseconds(),
-    ],
+    periodIntervals: [1, 7], // 1 day, 1 week
   },
   minute: {
     format: 'HH:mm',
     parentPeriod: 'day',
-    intervalsMs: [
-      moment.duration(1, 'minute').asMilliseconds(),
-      moment.duration(5, 'minutes').asMilliseconds(),
-      moment.duration(15, 'minutes').asMilliseconds(),
-      moment.duration(1, 'hour').asMilliseconds(),
-      moment.duration(3, 'hours').asMilliseconds(),
-      moment.duration(6, 'hours').asMilliseconds(),
-    ],
+    periodIntervals: [1, 5, 15, 60, 180, 360], // 1min, 5min, 15min, 1h, 3h, 6h
   },
 };

--- a/src/utils/timeline.js
+++ b/src/utils/timeline.js
@@ -48,7 +48,9 @@ export function getTimeScale({ focusedTimestamp, durationMsPerPixel }) {
     .range([-1, 1]);
 }
 
-export function findOptimalDurationFit(durationsMs, { durationMsPerPixel }) {
+export function findOptimalDurationFit(periodIntervals, period, { durationMsPerPixel }) {
   const minimalDurationMs = durationMsPerPixel * 1.1 * MIN_TICK_SPACING_PX;
-  return find(durationsMs, d => d >= minimalDurationMs);
+  return find(periodIntervals, (
+    p => moment.duration(p, period).asMilliseconds() >= minimalDurationMs
+  ));
 }


### PR DESCRIPTION
Will fix https://github.com/weaveworks/service-ui/issues/1534 when updated in `service-ui` repo.

The problem was that we were iterating through years by moving by `moment.duration(1, 'year').asMilliseconds()`. However, that integer is ambiguous and was one day short for leap years like 2016.

In this PR the iteration is done like `timestamp.add(1, 'year')` which always works correctly. The same iteration is also done for all other times units (for consistency).
