### PR TITLE
Shave off two pixels from Timeline min-range width

### DIFF
--- a/src/constants/timeline.js
+++ b/src/constants/timeline.js
@@ -5,7 +5,7 @@ export const MAX_TICK_SPACING_PX = 415;
 export const FADE_OUT_FACTOR = 1.4;
 export const TICKS_ROW_SPACING = 16;
 export const MAX_TICK_ROWS = 3;
-export const MIN_RANGE_INTERVAL_PX = 6;
+export const MIN_RANGE_INTERVAL_PX = 4;
 
 export const TICK_SETTINGS_PER_PERIOD = {
   year: {


### PR DESCRIPTION
Addresses https://github.com/weaveworks/service-ui/issues/1533#issuecomment-348170084 as part of https://github.com/weaveworks/service-ui/issues/1533.

Looks good on my Chrome and Firefox!
