### PR TITLE
Keep style files in npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,7 @@
 bin/
 dist/
 docs/
-src/
+src/*
 !src/styles/
 styleguide/
 


### PR DESCRIPTION
https://stackoverflow.com/a/5534865
> The pattern dir/ excludes a directory named dir and (implicitly) everything under it.
> With dir/, Git will never look at anything under dir, and thus will never apply any of the “un-exclude” patterns to anything under dir.

Currently the files inside the styles folder are not being included in the package.