### PR TITLE
Remove resolvers.js from npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,6 @@ src/*
 styleguide/
 
 circle.yml
-resolvers.js
 test-setup.js
 test-shim.js
 webpack.config.js


### PR DESCRIPTION
This is required by the service-ui dev server.

https://github.com/weaveworks/service-ui/blob/master/client/webpack.local.config.js#L6