### PR TITLE
Keep resolver files in npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@ dist/
 docs/
 src/*
 !src/styles/
+!src/resolvers/
 styleguide/
 
 circle.yml


### PR DESCRIPTION
`resolvers.js` required by the service-ui dev server imports `src/resolvers/`

Tested using `npm pack`, installing locally for `service-ui` and running the dev server.