### PR TITLE
Change the shade of grey in use throughout the product

### DIFF
--- a/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Alert /> snapshots renders default 1`] = `
 .c0 {
-  background: #f8f8f8;
+  background: #fafafc;
   border-radius: 4px;
   border: 2px solid #aaaaaa;
   color: #000;

--- a/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/src/components/Button/__snapshots__/Button.test.js.snap
@@ -18,7 +18,7 @@ exports[`<Button /> accepts a style prop 1`] = `
 .c0:hover {
   -webkit-transition: color .3s ease;
   transition: color .3s ease;
-  background: #f8f8f8;
+  background: #fafafc;
   color: #3c3c5b;
 }
 
@@ -88,7 +88,7 @@ exports[`<Button /> snapshots renders default 1`] = `
 .c0:hover {
   -webkit-transition: color .3s ease;
   transition: color .3s ease;
-  background: #f8f8f8;
+  background: #fafafc;
   color: #3c3c5b;
 }
 
@@ -111,7 +111,7 @@ exports[`<Button /> snapshots renders disabled 1`] = `
   border: 0;
   outline: none;
   box-shadow: 0 1px 3px rgba(0,0,0,0.12),0 1px 2px rgba(0,0,0,0.24);
-  background: #f8f8f8;
+  background: #fafafc;
   color: #aaaaaa;
   font-size: 0.875em;
   text-transform: uppercase;
@@ -121,7 +121,7 @@ exports[`<Button /> snapshots renders disabled 1`] = `
 .c0:hover {
   -webkit-transition: color .3s ease;
   transition: color .3s ease;
-  background: #f8f8f8;
+  background: #fafafc;
   color: #aaaaaa;
 }
 
@@ -187,7 +187,7 @@ exports[`<Button /> snapshots renders selected 1`] = `
 .c0:hover {
   -webkit-transition: color .3s ease;
   transition: color .3s ease;
-  background: #f8f8f8;
+  background: #fafafc;
   color: #3c3c5b;
 }
 

--- a/src/theme/weave.js
+++ b/src/theme/weave.js
@@ -15,7 +15,7 @@ const colors = {
   gray: '#aaaaaa',
   gunpowder: '#3c3c5b',
   lavender: '#8383ac',
-  lightgray: '#f8f8f8',
+  lightgray: '#fafafc',
   sand: '#f5f4f4',
   stratos: '#001755',
   turquoise: '#00bcd4',


### PR DESCRIPTION
I'd like the background colour of the right side box of the monitor dashboards to match the left side navigation bar colour.

Please correct me if I'm wrong, but I think that we use fafafc far more than f8f8f8?

![171212sidebarstandard1](https://user-images.githubusercontent.com/92439/34073614-5eaf72ca-e29d-11e7-9fa5-ed521591335e.png)

cc @weaveworks/keyboard-orchestra 