### PR TITLE
Small improvements to Time Travel UI

### DIFF
--- a/src/components/TimeTravel/_LiveModeToggle.js
+++ b/src/components/TimeTravel/_LiveModeToggle.js
@@ -19,9 +19,8 @@ const LiveModeToggleWrapper = styled.button`
   cursor: pointer;
 
   // Remove outline on Firefox
-  &::-moz-focus-inner {
-    border: 0;
-  }
+  &::-moz-focus-inner { border: 0; }
+  &:focus { outline: none; }
 
   @keyframes blinker {
     50% { opacity: 0.5; }

--- a/src/components/TimeTravel/_RangeSelector.js
+++ b/src/components/TimeTravel/_RangeSelector.js
@@ -51,7 +51,7 @@ const CaretIconsContainer = styled.span`
   margin-left: 8px;
 
   .fa {
-    font-size: 75%;
+    font-size: 12px;
     line-height: 7px;
   }
 `;

--- a/src/components/TimeTravel/_RangeSelector.js
+++ b/src/components/TimeTravel/_RangeSelector.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 
-const HEIGHT = '27px';
+const HEIGHT_PX = 27;
 
 const RangeSelectorWrapper = styled.div`
   border-left: 1px solid ${props => props.theme.colors.neutral.lightgray};
@@ -57,7 +57,7 @@ const CaretIconsContainer = styled.span`
 `;
 
 const RangeOption = styled.div`
-  line-height: ${HEIGHT};
+  line-height: ${HEIGHT_PX}px;
   cursor: pointer;
   padding: 0 8px;
 
@@ -108,10 +108,11 @@ class RangeSelector extends React.Component {
     const { rangeMs } = this.props;
     const { isOpen } = this.state;
 
+    const selectedRangeIndex = rangeOptions.findIndex(r => r.valueMs === rangeMs);
     const selectedRangeLabel = rangeOptions.find(r => r.valueMs === rangeMs).label;
     const anchorEl = this.containerRef && this.containerRef.getBoundingClientRect();
     const menuStyle = anchorEl ? {
-      top: anchorEl.top - 1,
+      top: anchorEl.top - (selectedRangeIndex * HEIGHT_PX) - 1,
       left: anchorEl.right - anchorEl.width,
       minWidth: anchorEl.width + 1,
     } : {};


### PR DESCRIPTION
Addresses parts of #71.

##### Changes

* Vertically aligned _RangeSelector_ dropdown to currently selected element
* Got rid of relative font-size in RangeSelector component (used to cause problems before)
* Removed the Firefox _LiveModeToggle_ button outline

##### Needs more discussion

* Are we good with the current range intervals?
* Live/paused states
  * Do we keep the text or just the icons?
  * How exactly should the transition look like?