### PR TITLE
Only run CI steps on publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:components": "babel src/components --out-dir lib/components --ignore *.test.js,example.js",
     "build:index": "babel src/index.js --out-file lib/index.js",
     "postversion": "git push origin --follow-tags",
-    "prepublish": "yarn ci && yarn build",
+    "prepublishOnly": "yarn ci && yarn build",
     "postpublish": "yarn docs:publish",
     "docs:build": "RELEASE=true rm -rf dist && webpack --config webpack.config.js",
     "docs:copy-images": "cp -R src/images dist/images",


### PR DESCRIPTION
Fixes an issue where tests were running after installing this lib via `yarn install`.

cc @aaron7 