### PR TITLE
Add Dropdown component

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,11 @@
 {
-  "plugins" : ["transform-export-extensions", "transform-object-rest-spread"],
+  "plugins" : [
+    "transform-export-extensions",
+    "transform-object-rest-spread",
+    [
+      "styled-components", {
+      "displayName": true
+    }]
+  ],
   "presets": ["es2015", "react"]
 }

--- a/docs/js/routes.js
+++ b/docs/js/routes.js
@@ -12,7 +12,7 @@ function buildExampleComponent(el, doc, example, sub) {
   return function ExampleWrapper() {
     return (
       <Example
-        name={el.name}
+        name={el.displayName || el.name}
         element={el}
         example={example}
         doc={doc}

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "babel-eslint": "7.1.1",
     "babel-jest": "^17.0.2",
     "babel-loader": "6.2.8",
+    "babel-plugin-styled-components": "^1.3.0",
     "babel-plugin-transform-export-extensions": "6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "6.18.0",

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -1,0 +1,189 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+import { map, find } from 'lodash';
+
+const WIDTH = '256px';
+const HEIGHT = '36px';
+
+const Item = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 0 24px;
+  cursor: pointer;
+`;
+
+const Popover = styled.div`
+  position: absolute;
+  background-color: ${props => props.theme.colors.white};
+  border: 1px solid ${props => props.theme.colors.neutral.lightgray};
+  border-radius: 4px;
+  z-index: 3;
+  box-shadow: ${props => props.theme.boxShadow.light};
+  margin-top: 4px;
+  width: ${WIDTH};
+`;
+
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  z-index: 2;
+`;
+
+const ItemWrapper = Item.extend`
+  line-height: ${HEIGHT};
+  color: ${props => (props.selected ? props.theme.colors.accent.blue : props.theme.textColor)};
+  min-height: ${HEIGHT};
+
+  &:hover {
+    background-color: #eee;
+  }
+
+  &:last-child {
+    border-bottom: 0;
+  }
+`;
+
+const SelectedItem = Item.extend`
+  border-radius: 4px;
+  background-color: ${props => props.theme.colors.neutral.white};
+  border: 1px solid ${props => props.theme.colors.neutral.gray};
+  display: flex;
+
+  ${Item} {
+    padding: 0;
+  }
+
+  div:last-child {
+    margin-left: auto;
+  }
+`;
+
+const SelectedItemIcon = styled.span`
+  padding-left: 1em;
+  float: right;
+  line-height: ${HEIGHT};
+`;
+
+const StyledDropdown = component => styled(component)`
+  display: inline-block;
+  height: ${HEIGHT};
+  line-height: ${HEIGHT};
+  position: relative;
+  padding: 8px;
+  width: ${WIDTH};
+`;
+
+/**
+ * A selectable drop-down menu.
+ * ```javascript
+ *const items = [
+ *  {
+ *    value: 'first-thing',
+ *    label: 'First Thing',
+ *  },
+ *  {
+ *    value: 'second-thing',
+ *    label: 'Second Thing',
+ *  },
+ *  {
+ *    value: 'third-thing',
+ *    label: 'Super long thing, this get truncated',
+ *  },
+ * ];
+ *
+ * <Dropdown items={items} />
+ * ```
+ */
+
+class Dropdown extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+
+    this.state = {
+      isOpen: false,
+    };
+
+    this.handleChange = this.handleChange.bind(this);
+    this.handleClick = this.handleClick.bind(this);
+    this.handleBgClick = this.handleBgClick.bind(this);
+  }
+
+  handleChange(ev, value) {
+    this.setState({ isOpen: false });
+    if (this.props.onChange) {
+      this.props.onChange(ev, value);
+    }
+  }
+
+  handleClick() {
+    this.setState({ isOpen: true });
+  }
+
+  handleBgClick() {
+    this.setState({ isOpen: false });
+  }
+
+  render() {
+    const { items, value, className } = this.props;
+    const { isOpen } = this.state;
+    const currentItem = find(items, i => i.value === value) || (items && items[0]);
+
+    return (
+      <div className={className}>
+        <SelectedItem onClick={this.handleClick}>
+          <Item>
+            {currentItem && currentItem.label}
+          </Item>
+          <div>
+            <SelectedItemIcon className="fa fa-caret-down" />
+          </div>
+        </SelectedItem>
+        {isOpen &&
+          <div>
+            <Popover>
+              {map(this.props.items, i => (
+                <ItemWrapper
+                  key={i.value}
+                  onClick={ev => this.handleChange(ev, i.value)}
+                  selected={i.value === value}
+                >
+                  {i.label}
+                </ItemWrapper>
+              ))}
+            </Popover>
+            <Overlay onClick={this.handleBgClick} />
+          </div>
+        }
+      </div>
+    );
+  }
+}
+
+Dropdown.propTypes = {
+  /**
+   * Array of items that will be selectable. `value` should be an internal value,
+   * `label` is what will be displayed to the user.
+   */
+  items: PropTypes.arrayOf(PropTypes.shape({
+    value: PropTypes.string,
+    label: PropTypes.string
+  })).isRequired,
+  /**
+   * The value of the currently selected item. This much match a value in the `items` prop.
+   * If no value is provided, the first elements's value will be used.
+   */
+  value: PropTypes.string,
+  /**
+   * A handler function that will run when a value is selected.
+   */
+  onChange: PropTypes.func,
+
+};
+
+export default StyledDropdown(Dropdown);

--- a/src/components/Dropdown/Dropdown.test.js
+++ b/src/components/Dropdown/Dropdown.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import 'jest-styled-components';
+import { withTheme } from '../../utils/theme';
+
+import Dropdown from './Dropdown';
+
+describe('<Dropdown />', () => {
+  const items = [
+    {
+      value: 'first-thing',
+      label: 'First Thing',
+    },
+    {
+      value: 'second-thing',
+      label: 'Second Thing',
+    },
+    {
+      value: 'third-thing',
+      label: 'Super long thing, this should get truncated',
+    },
+  ];
+
+  describe('snapshots', () => {
+    it('renders default', () => {
+      const tree = renderer.create(withTheme(<Dropdown items={items} />)).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  it('is extendable', () => {
+    // Make sure a styled-component gets exported
+    expect(typeof Dropdown.extend).toEqual('function');
+    expect(Dropdown.displayName).toEqual('Dropdown');
+  });
+});

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Dropdown /> snapshots renders default 1`] = `
+.c3 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 0 24px;
+  cursor: pointer;
+}
+
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 0 24px;
+  cursor: pointer;
+  border-radius: 4px;
+  background-color: #fff;
+  border: 1px solid #9a9a9a;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 .c2 {
+  padding: 0;
+}
+
+.c1 div:last-child {
+  margin-left: auto;
+}
+
+.c4 {
+  padding-left: 1em;
+  float: right;
+  line-height: 36px;
+}
+
+.c0 {
+  display: inline-block;
+  height: 36px;
+  line-height: 36px;
+  position: relative;
+  padding: 8px;
+  width: 256px;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+    onClick={[Function]}
+  >
+    <div
+      className="c2 c3"
+    >
+      First Thing
+    </div>
+    <div>
+      <span
+        className="fa fa-caret-down c4"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/Dropdown/example.js
+++ b/src/components/Dropdown/example.js
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import Dropdown from '.';
+
+const items = [
+  {
+    value: 'first-thing',
+    label: 'First Thing',
+  },
+  {
+    value: 'second-thing',
+    label: 'Second Thing',
+  },
+  {
+    value: 'third-thing',
+    label: 'Super long thing, this should get truncated',
+  },
+];
+
+export default class DropdownExample extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      selected: items[0].value,
+    };
+  }
+
+  render() {
+    const onChange = (ev, value) => {
+      this.setState(() => ({ selected: value }));
+    };
+
+    return (
+      <div>
+        <Dropdown items={items} value={this.state.selected} onChange={onChange} />
+      </div>
+    );
+  }
+}

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -1,0 +1,1 @@
+export default from './Dropdown';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -24,3 +24,5 @@ export Text from './Text';
 export Alert from './Alert';
 
 export TimeTravel from './TimeTravel';
+
+export Dropdown from './Dropdown';

--- a/yarn.lock
+++ b/yarn.lock
@@ -526,6 +526,13 @@ babel-plugin-jest-hoist@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz#afedc853bd3f8dc3548ea671fbe69d03cc2c1767"
 
+babel-plugin-styled-components@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.3.0.tgz#9e4d9f718b2975dadbfab0bc1c6793d93c751404"
+  dependencies:
+    babel-types "^6.26.0"
+    stylis "3.x"
+
 babel-plugin-syntax-export-extensions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz#70a1484f0f9089a4e84ad44bac353c95b9b12721"
@@ -6231,7 +6238,7 @@ styled-normalize@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/styled-normalize/-/styled-normalize-2.2.1.tgz#c93a007c0339a69e3254eeef8cb6a5a96e5ca4eb"
 
-stylis@^3.2.1:
+stylis@3.x, stylis@^3.2.1:
   version "3.4.5"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.4.5.tgz#d7b9595fc18e7b9c8775eca8270a9a1d3e59806e"
 


### PR DESCRIPTION
Fixes #66 

Adds a generic dropdown component:
![screen shot 2017-12-19 at 11 36 03 am](https://user-images.githubusercontent.com/2802257/34175294-d7547274-e4b0-11e7-8733-81caba233cb9.png)

One component to rule them all! Should be overridable and usable for both the instance selector and whatever other dropdowns we want.

