### PR TITLE
Call onChangeLiveMode on every mode change

### DIFF
--- a/src/components/TimeTravel/TimeTravel.js
+++ b/src/components/TimeTravel/TimeTravel.js
@@ -231,17 +231,20 @@ class TimeTravel extends React.Component {
   }
 
   handleTimelineJump(timestamp) {
-    this.setState({ showingLive: false });
+    //  Order of callbacks is important.
+    this.switchToPausedMode();
     this.setFocusedTimestamp(timestamp);
     this.props.onTimelineLabelClick();
   }
 
   handleTimelinePanButtonClick(timestamp) {
     if (this.shouldStickySwitchToLiveMode({ focusedTimestamp: timestamp })) {
-      this.setState({ showingLive: true });
+      //  Order of callbacks is important.
       this.setFocusedTimestamp(this.state.timestampNow);
+      this.switchToLiveMode();
     } else {
-      this.setState({ showingLive: false });
+      //  Order of callbacks is important.
+      this.switchToPausedMode();
       this.setFocusedTimestamp(timestamp);
     }
     this.props.onTimelinePanButtonClick();
@@ -254,15 +257,18 @@ class TimeTravel extends React.Component {
   }
 
   handleTimelinePan(timestamp) {
+    //  Order of callbacks is important.
     const focusedTimestamp = this.clampedTimestamp(timestamp);
-    this.setState({ showingLive: false, focusedTimestamp });
+    this.switchToPausedMode();
+    this.setState({ focusedTimestamp });
     this.delayedOnChangeTimestamp(focusedTimestamp);
   }
 
   handleTimelineRelease() {
     if (this.shouldStickySwitchToLiveMode()) {
-      this.setState({ showingLive: true });
+      //  Order of callbacks is important.
       this.setFocusedTimestamp(this.state.timestampNow);
+      this.switchToLiveMode();
     }
     this.props.onTimelinePan();
   }
@@ -272,11 +278,27 @@ class TimeTravel extends React.Component {
   }
 
   handleLiveModeToggle(showingLive) {
-    this.setState({ showingLive });
     if (showingLive) {
+      //  Order of callbacks is important.
       this.setState({ focusedTimestamp: this.state.timestampNow });
+      this.switchToLiveMode();
+    } else {
+      this.switchToPausedMode();
     }
-    this.props.onChangeLiveMode(showingLive);
+  }
+
+  switchToLiveMode() {
+    if (!this.state.showingLive) {
+      this.setState({ showingLive: true });
+      this.props.onChangeLiveMode(true);
+    }
+  }
+
+  switchToPausedMode() {
+    if (this.state.showingLive) {
+      this.setState({ showingLive: false });
+      this.props.onChangeLiveMode(false);
+    }
   }
 
   setFocusedTimestamp(timestamp) {


### PR DESCRIPTION
Fixes https://github.com/weaveworks/service-ui/issues/1674.

The problem was that the `onChangeLiveMode` handler would only be called when clicking on the Live/Paused toggle button, so the users of TimeTravel component would still think e.g. we stayed in the live mode after panning away the timeline into the paused state.

Now the callback is used whenever the mode switching happens:

* Live/Paused toggle button click
* Clicking on a Timeline label
* Clicking on a Timeline pan button
* Panning the Timeline

