### PR TITLE
Make Time Travel react to showingLive prop change

### DIFF
--- a/src/components/TimeTravel/TimeTravel.js
+++ b/src/components/TimeTravel/TimeTravel.js
@@ -178,18 +178,20 @@ class TimeTravel extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    // Don't update the timestamp if in live mode.
-    if (this.props.hasLiveMode && nextProps.showingLive) return;
-
-    // Keep the most recent live timestamp if just switched from live to paused.
-    if (!nextProps.showingLive && this.props.showingLive) return;
-
-    // Don't update the focused timestamp if we're not paused (so the timeline is hidden).
-    if (nextProps.timestamp) {
-      this.setState({
-        focusedTimestamp: formattedTimestamp(nextProps.timestamp),
-        rangeMs: nextProps.rangeMs,
-      });
+    // If live mode is supported and we're in it, ignore the timestamp prop and jump
+    // directly to the present timestamp, otherwise jump to the given timestamp prop.
+    if (nextProps.hasLiveMode && nextProps.showingLive) {
+      this.setState({ focusedTimestamp: this.state.timestampNow });
+    } else {
+      this.setState({ focusedTimestamp: formattedTimestamp(nextProps.timestamp) });
+    }
+    // Update live mode only if live mode toggle is enabled.
+    if (nextProps.hasLiveMode) {
+      this.setState({ showingLive: nextProps.showingLive });
+    }
+    // Update selected range only if range selector is used.
+    if (nextProps.hasRangeSelector) {
+      this.setState({ rangeMs: nextProps.rangeMs });
     }
   }
 
@@ -370,8 +372,6 @@ class TimeTravel extends React.Component {
   }
 }
 
-// TODO: Consider removing `showingLive` property. See the PR comment for details:
-// https://github.com/weaveworks/ui-components/pull/68#discussion_r152771727
 TimeTravel.propTypes = {
   /**
    * The timestamp in focus


### PR DESCRIPTION
This is a prerequisite for https://github.com/weaveworks/service-ui/pull/1523 to work well with Back/Forward browser buttons as there would be cases where `showingLive` bool would be modified from the URL query params and would have to be applied to Time Travel state from the outside, through _props_.

This case also justifies the use of `showingLive` as a prop, so I removed the comment that references the question raised in https://github.com/weaveworks/ui-components/pull/68#discussion_r152771727.