### PR TITLE
Balance dropdown paddings

### DIFF
--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -11,7 +11,7 @@ const Item = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  padding: 0 24px;
+  padding: 0 12px;
   cursor: pointer;
 `;
 
@@ -25,6 +25,7 @@ const Popover = styled.div`
   margin-top: 4px;
   width: ${WIDTH};
   box-sizing: border-box;
+  padding: 6px 0;
 `;
 
 const Overlay = styled.div`
@@ -43,15 +44,6 @@ const ItemWrapper = Item.extend`
 
   &:hover {
     background-color: #eee;
-  }
-
-  &:first-child {
-    border-radius: ${props => props.theme.borderRadius} 0 0;
-  }
-
-  &:last-child {
-    border-bottom: 0;
-    border-radius: 0 0 ${props => props.theme.borderRadius};
   }
 `;
 

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -5,7 +5,7 @@ exports[`<Dropdown /> snapshots renders default 1`] = `
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  padding: 0 24px;
+  padding: 0 12px;
   cursor: pointer;
 }
 
@@ -13,7 +13,7 @@ exports[`<Dropdown /> snapshots renders default 1`] = `
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  padding: 0 24px;
+  padding: 0 12px;
   cursor: pointer;
   border-radius: 4px;
   background-color: #fff;

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -32,7 +32,7 @@ const StyledInput = component => styled(component)`
   input {
     ${props => placeholder(props.theme.colors.neutral.gray)};
     display: inline-block;
-    padding: 0 24px;
+    padding: 0 12px;
     line-height: 36px;
     box-shadow: none;
     border: 1px solid ${props => props.theme.colors.neutral.gray};


### PR DESCRIPTION
- Reduce left-padding from 24px to 12px
- Introduce padding at top/bottom of items container to balance ws

![ui-components-dropdown](https://user-images.githubusercontent.com/32963/34613324-4501d15a-f225-11e7-855f-1df8f5ead1e0.png)
