### PR TITLE
 Add `info` type for Alert component

### DIFF
--- a/src/components/Alert/Alert.js
+++ b/src/components/Alert/Alert.js
@@ -31,7 +31,7 @@ const CloseIcon = styled.i`
  *  return (
  *    <div>
  *     <Alert type="warning" visible={true}>
- *       Warning: Hmm, this is not good, but its not terrible.
+ *       Warning: Hmm, this is not good, but it is not terrible.
  *     </Alert>
  *    </div>
  *   )

--- a/src/components/Alert/Alert.js
+++ b/src/components/Alert/Alert.js
@@ -52,7 +52,7 @@ Alert.propTypes = {
   /**
    * Set the color scheme to indicate the nature of the alert.
    */
-  type: PropTypes.oneOf(['default', 'success', 'warning', 'error']),
+  type: PropTypes.oneOf(['default', 'info', 'success', 'warning', 'error']),
 
   /**
    * Toggle whether the alert is shown

--- a/src/components/Alert/example.js
+++ b/src/components/Alert/example.js
@@ -24,7 +24,7 @@ export default class AlertExample extends React.Component {
       <Grid>
         <GridRow>
           <Alert visible={this.state.default} onClose={onClose('default')}>
-            Default: This is a default alert. Its just giving you some info.
+            Default: This is a default alert. It is just giving you some info.
           </Alert>
         </GridRow>
         <GridRow>
@@ -39,7 +39,7 @@ export default class AlertExample extends React.Component {
         </GridRow>
         <GridRow>
           <Alert type="warning" visible={this.state.warning} onClose={onClose('warning')}>
-            Warning: Hmm, this is not good, but its not terrible.
+            Warning: Hmm, this is not good, but it is not terrible.
           </Alert>
         </GridRow>
         <GridRow>

--- a/src/components/Alert/example.js
+++ b/src/components/Alert/example.js
@@ -7,6 +7,7 @@ import Alert from '.';
 
 const initial = {
   default: true,
+  info: true,
   success: true,
   warning: true,
   error: true,
@@ -23,7 +24,12 @@ export default class AlertExample extends React.Component {
       <Grid>
         <GridRow>
           <Alert visible={this.state.default} onClose={onClose('default')}>
-            Info: This is a default alert. Its just giving you some info.
+            Default: This is a default alert. Its just giving you some info.
+          </Alert>
+        </GridRow>
+        <GridRow>
+          <Alert type="info" visible={this.state.info} onClose={onClose('info')}>
+            Info: Please pay attention to this.
           </Alert>
         </GridRow>
         <GridRow>

--- a/src/theme/weave.js
+++ b/src/theme/weave.js
@@ -97,6 +97,11 @@ const weave = {
         background: colors.lightgray,
         borderColor: colors.gray,
       },
+      info: {
+        color: colors.white,
+        background: colors.status.info,
+        borderColor: darken(0.15, colors.status.info),
+      },
       success: {
         color: colors.white,
         background: colors.status.success,


### PR DESCRIPTION
There is a slight confusion about default/info currently (code uses
default but text mentions info).

In addition to success/warning/error types, it makes sense to have two
more where one is shallow and the other emphasized.

`default` is currently blending in with the background as it's light
gray. The one this PR adds (`info`) would be emphasized. I took the
already existing status color for the `info` type.

![ui-components-alerts](https://user-images.githubusercontent.com/32963/34873696-0b0e9f78-f78e-11e7-83e2-baca2d36b5ff.png)
