### PR TITLE
Use semantic components to mark examples

### DIFF
--- a/src/components/Alert/example.js
+++ b/src/components/Alert/example.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Grid, GridRow } from '../Grid';
+import { Example } from '../../utils/example';
 import Button from '../Button';
 
 import Alert from '.';
@@ -20,29 +20,29 @@ export default class AlertExample extends React.Component {
   render() {
     const onClose = id => () => this.setState({ [id]: false });
     return (
-      <Grid>
-        <GridRow>
+      <div>
+        <Example>
           <Alert visible={this.state.default} onClose={onClose('default')}>
             Info: This is a default alert. Its just giving you some info.
           </Alert>
-        </GridRow>
-        <GridRow>
+        </Example>
+        <Example>
           <Alert type="success" visible={this.state.success} onClose={onClose('success')}>
             Success: Great job! Wow! Much success!
           </Alert>
-        </GridRow>
-        <GridRow>
+        </Example>
+        <Example>
           <Alert type="warning" visible={this.state.warning} onClose={onClose('warning')}>
             Warning: Hmm, this is not good, but its not terrible.
           </Alert>
-        </GridRow>
-        <GridRow>
+        </Example>
+        <Example>
           <Alert type="error" visible={this.state.error} onClose={onClose('error')}>
             Error: Wow you really screwed this up...
           </Alert>
-        </GridRow>
+        </Example>
         <Button onClick={() => this.setState(initial)} text="Reset" />
-      </Grid>
+      </div>
     );
   }
 }

--- a/src/components/Button/example.js
+++ b/src/components/Button/example.js
@@ -1,16 +1,17 @@
 import React from 'react';
 
+import { Example } from '../../utils/example';
 import Button from '.';
 
 export default function ButtonExample({ clickHandler }) {
   const onClick = (ev, text) => clickHandler('onClick', text);
   return (
     <div>
-      <p><Button onClick={onClick} text="Submit" /></p>
-      <p><Button disabled onClick={onClick} text="Disabled" /></p>
-      <p><Button primary onClick={onClick} text="Primary" /></p>
-      <p><Button selected onClick={onClick} text="Selected" /></p>
-      <p><Button danger onClick={onClick} text="Danger" /></p>
+      <Example><Button onClick={onClick} text="Submit" /></Example>
+      <Example><Button disabled onClick={onClick} text="Disabled" /></Example>
+      <Example><Button primary onClick={onClick} text="Primary" /></Example>
+      <Example><Button selected onClick={onClick} text="Selected" /></Example>
+      <Example><Button danger onClick={onClick} text="Danger" /></Example>
     </div>
   );
 }

--- a/src/components/Dialog/example.js
+++ b/src/components/Dialog/example.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-no-bind*/
 import React from 'react';
 
+import { Example, Info } from '../../utils/example';
 import Dialog from '.';
 import Button from '../Button';
 
@@ -43,27 +44,31 @@ export default class DialogExample extends React.Component {
     );
     return (
       <div>
-        <p>Normal dialog with overlay</p>
-        <Dialog
-          active={this.state.normalButtonActive}
-          actions={['Submit', 'Cancel']}
-          onClose={this.handleClose}
-          onActionClick={this.handleClose}
-          overlay
+        <Example>
+          <Info>Normal dialog with overlay</Info>
+          <Dialog
+            active={this.state.normalButtonActive}
+            actions={['Submit', 'Cancel']}
+            onClose={this.handleClose}
+            onActionClick={this.handleClose}
+            overlay
         >
-          <p>Here is some content that I would like to display</p>
-        </Dialog>
-        <Button onClick={this.handleDialogActivate.bind(this, 'normal')} text="Dialog" />
-        <p>Dialog with pre-created actions</p>
-        <Button onClick={this.handleDialogActivate.bind(this, 'other')} text="Custom Actions" />
-        <Dialog
-          active={this.state.otherButtonActive}
-          actions={[<Action1 />, <Action2 />]}
-          onClose={this.handleClose}
-          overlay
+            <p>Here is some content that I would like to display</p>
+          </Dialog>
+          <Button onClick={this.handleDialogActivate.bind(this, 'normal')} text="Dialog" />
+        </Example>
+        <Example>
+          <Info>Dialog with pre-created actions</Info>
+          <Button onClick={this.handleDialogActivate.bind(this, 'other')} text="Custom Actions" />
+          <Dialog
+            active={this.state.otherButtonActive}
+            actions={[<Action1 />, <Action2 />]}
+            onClose={this.handleClose}
+            overlay
         >
-          <p>This one has custom actions</p>
-        </Dialog>
+            <p>This one has custom actions</p>
+          </Dialog>
+        </Example>
       </div>
     );
   }

--- a/src/components/Dropdown/example.js
+++ b/src/components/Dropdown/example.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { Example } from '../../utils/example';
 import Dropdown from '.';
 
 const items = [
@@ -32,7 +33,9 @@ export default class DropdownExample extends React.Component {
 
     return (
       <div>
-        <Dropdown items={items} value={this.state.selected} onChange={onChange} />
+        <Example>
+          <Dropdown items={items} value={this.state.selected} onChange={onChange} />
+        </Example>
       </div>
     );
   }

--- a/src/components/Grid/example.js
+++ b/src/components/Grid/example.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import times from 'lodash/times';
 
+import { Example, Info } from '../../utils/example';
 import { Grid, GridColumn, GridRow as Row } from '.';
 
 export default function GridExample() {
@@ -14,10 +15,11 @@ export default function GridExample() {
   }
   return (
     <div>
-      <Grid>
-        <Row>
-          <GridColumn span={4}>
-            <p>First Col (span 4)</p>
+      <Example>
+        <Grid>
+          <Row>
+            <GridColumn span={4}>
+              <p>First Col (span 4)</p>
             Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
             ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
             ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
@@ -25,8 +27,8 @@ export default function GridExample() {
             Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
             anim id est laborum.
           </GridColumn>
-          <GridColumn span={8}>
-            <p>Second Col (span 8)</p>
+            <GridColumn span={8}>
+              <p>Second Col (span 8)</p>
             Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
             ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
             ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
@@ -34,72 +36,74 @@ export default function GridExample() {
             Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
             anim id est laborum.
           </GridColumn>
-        </Row>
-
-      </Grid>
-      <br />
-      <p><b>A grid with three columns (span 4)</b></p>
-      <br />
-      <Grid>
-        <Row>
-          <GridColumn span={4}>
-            <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
-          </GridColumn>
-          <GridColumn span={4}>
-            <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
-          </GridColumn>
-          <GridColumn span={4}>
-            <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
-          </GridColumn>
-        </Row>
-      </Grid>
-      <br />
-      <p><b>A grid with 12 columns (span 1)</b></p>
-      <br />
-      <Grid>
-        <Row>
-          {twelve}
-        </Row>
-
-      </Grid>
-      <p><b>Using a Row with alignContent</b></p>
-      <Grid>
-        <Row alignContent="center">
-          <GridColumn span={4}>
-            <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
-          </GridColumn>
-          <GridColumn span={4}>
-            <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
-          </GridColumn>
-        </Row>
-        <Row alignContent="left">
-          <GridColumn span={4}>
-            <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
-          </GridColumn>
-          <GridColumn span={4}>
-            <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
-          </GridColumn>
-        </Row>
-        <Row alignContent="right">
-          <GridColumn span={4}>
-            <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
-          </GridColumn>
-          <GridColumn span={4}>
-            <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
-          </GridColumn>
-        </Row>
-      </Grid>
-      <p><b>Use columns without a {'<Row />'} element to get items to wrap nicely</b></p>
-      <Grid>
-        {
+          </Row>
+        </Grid>
+      </Example>
+      <Example>
+        <Info>A grid with three columns (span 4)</Info>
+        <Grid>
+          <Row>
+            <GridColumn span={4}>
+              <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
+            </GridColumn>
+            <GridColumn span={4}>
+              <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
+            </GridColumn>
+            <GridColumn span={4}>
+              <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
+            </GridColumn>
+          </Row>
+        </Grid>
+      </Example>
+      <Example>
+        <Info>A grid with 12 columns (span 1)</Info>
+        <Grid>
+          <Row>
+            {twelve}
+          </Row>
+        </Grid>
+      </Example>
+      <Example>
+        <Info>Using a Row with alignContent</Info>
+        <Grid>
+          <Row alignContent="center">
+            <GridColumn span={4}>
+              <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
+            </GridColumn>
+            <GridColumn span={4}>
+              <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
+            </GridColumn>
+          </Row>
+          <Row alignContent="left">
+            <GridColumn span={4}>
+              <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
+            </GridColumn>
+            <GridColumn span={4}>
+              <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
+            </GridColumn>
+          </Row>
+          <Row alignContent="right">
+            <GridColumn span={4}>
+              <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
+            </GridColumn>
+            <GridColumn span={4}>
+              <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
+            </GridColumn>
+          </Row>
+        </Grid>
+      </Example>
+      <Example>
+        <Info>Use columns without a {'<Row />'} element to get items to wrap nicely</Info>
+        <Grid>
+          {
           times(20, i => (
             <GridColumn key={i} span={1}>
               <div style={{backgroundColor: '#8383ac', height: '200px', width: '100%'}} />
             </GridColumn>
           ))
         }
-      </Grid>
+        </Grid>
+      </Example>
     </div>
-
   );
 }

--- a/src/components/Input/example.js
+++ b/src/components/Input/example.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { Example, Info } from '../../utils/example';
 import Input from '.';
 
 
@@ -8,11 +9,13 @@ const onChange = () => null;
 export default function InputExample() {
   return (
     <div>
-      <div>
+      <Example>
+        <Info>Plain inputs</Info>
         <Input label="Username" placeholder="your name here" onChange={onChange} />
         <Input label="Email" value="ron@hogwarts.edu" onChange={onChange} />
-      </div>
-      <div>
+      </Example>
+      <Example>
+        <Info>With validation</Info>
         <Input
           label="Email"
           value="invalid-email"
@@ -21,7 +24,7 @@ export default function InputExample() {
           onChange={onChange}
         />
         <Input label="Password" type="password" onChange={onChange} />
-      </div>
+      </Example>
     </div>
   );
 }

--- a/src/components/ListItem/example.js
+++ b/src/components/ListItem/example.js
@@ -1,4 +1,6 @@
 import React from 'react';
+
+import { Example } from '../../utils/example';
 import { ListItem } from '.';
 
 
@@ -7,19 +9,21 @@ export default function ListItemExample({ clickHandler }) {
   const icon = <span className="fa fa-star" />;
   return (
     <div>
-      <ListItem
-        text="Item 1"
+      <Example>
+        <ListItem
+          text="Item 1"
         />
-      <ListItem
-        onClick={onClick}
-        text="Item 2"
-        subText="You can click on this one"
+        <ListItem
+          onClick={onClick}
+          text="Item 2"
+          subText="You can click on this one"
         />
-      <ListItem
-        text="Item 3"
-        leftIcon={icon}
-        subText="With an icon"
+        <ListItem
+          text="Item 3"
+          leftIcon={icon}
+          subText="With an icon"
       />
+      </Example>
     </div>
   );
 }

--- a/src/components/MatchedText/example.js
+++ b/src/components/MatchedText/example.js
@@ -1,19 +1,20 @@
 import React from 'react';
 
+import { Example } from '../../utils/example';
 import MatchedText from '.';
 
 export default function MatchedTextExample() {
   return (
-    <ul>
-      <li>
+    <div>
+      <Example>
         <MatchedText text="no `match` prop on this MatchedText" />
-      </li>
-      <li>
+      </Example>
+      <Example>
         <MatchedText text="empty `match` object ({}) on this MatchedText" match={{}} />
-      </li>
-      <li>
+      </Example>
+      <Example>
         <MatchedText text="hey its a match!" match={{start: 10, length: 5}} />
-      </li>
-    </ul>
+      </Example>
+    </div>
   );
 }

--- a/src/components/Menu/example.js
+++ b/src/components/Menu/example.js
@@ -1,5 +1,7 @@
 /* eslint-disable react/jsx-no-bind*/
 import React from 'react';
+
+import { Example } from '../../utils/example';
 import {Menu, MenuItem} from '.';
 
 export default class Name extends React.Component {
@@ -18,20 +20,24 @@ export default class Name extends React.Component {
   }
   render() {
     return (
-      <Menu>
-        <MenuItem active={this.isActive('Item 1')} onClick={this.handleItemClick} text="Item 1" />
-        <MenuItem active={this.isActive('Item 2')} onClick={this.handleItemClick} text="Item 2" />
-        <MenuItem
-          active={this.isActive('Sub Item 1')}
-          onClick={this.handleItemClick}
-          className="weave-menu-sub-item" text="Sub Item 1"
+      <div>
+        <Example>
+          <Menu>
+            <MenuItem active={this.isActive('Item 1')} onClick={this.handleItemClick} text="Item 1" />
+            <MenuItem active={this.isActive('Item 2')} onClick={this.handleItemClick} text="Item 2" />
+            <MenuItem
+              active={this.isActive('Sub Item 1')}
+              onClick={this.handleItemClick}
+              className="weave-menu-sub-item" text="Sub Item 1"
         />
-        <MenuItem
-          active={this.isActive('Sub Item 2')}
-          onClick={this.handleItemClick}
-          className="weave-menu-sub-item" text="Sub Item 2"
+            <MenuItem
+              active={this.isActive('Sub Item 2')}
+              onClick={this.handleItemClick}
+              className="weave-menu-sub-item" text="Sub Item 2"
         />
-      </Menu>
+          </Menu>
+        </Example>
+      </div>
     );
   }
 }

--- a/src/components/Text/example.js
+++ b/src/components/Text/example.js
@@ -1,38 +1,39 @@
 import React from 'react';
 
+import { Example } from '../../utils/example';
 import Text from '.';
 
 export default function TextExample() {
   return (
     <div>
-      <p>
+      <Example>
         <Text>Normal</Text>
-      </p>
-      <p>
+      </Example>
+      <Example>
         <Text italic>Normal Italic</Text>
-      </p>
-      <p>
+      </Example>
+      <Example>
         <Text bold>Normal Bold</Text>
-      </p>
-      <p>
+      </Example>
+      <Example>
         <Text large>Large</Text>
-      </p>
-      <p>
+      </Example>
+      <Example>
         <Text large italic>Large Italic</Text>
-      </p>
-      <p>
+      </Example>
+      <Example>
         <Text large bold>Large Bold</Text>
-      </p>
-      <p>
+      </Example>
+      <Example>
         <Text xl>Extra Large</Text>
-      </p>
-      <p>
+      </Example>
+      <Example>
         <Text xl italic>Extra Large Italic</Text>
-      </p>
-      <p>
+      </Example>
+      <Example>
         <Text xl bold>Extra Large Bold</Text>
-      </p>
-      <div>
+      </Example>
+      <Example>
         <Text>
           Quo non arbitrantur. Et irure comprehenderit iis nescius duis officia cernantur.
           Quae eiusmod voluptatibus, o se magna fugiat quid, culpa adipisicing quamquam
@@ -46,7 +47,7 @@ export default function TextExample() {
           exquisitaque, ingeniis ex eram admodum, quibusdam reprehenderit quo arbitror,
           hic multos consequat.
         </Text>
-      </div>
+      </Example>
     </div>
   );
 }

--- a/src/components/WeaveCloudLogo/example.js
+++ b/src/components/WeaveCloudLogo/example.js
@@ -1,18 +1,21 @@
 import React from 'react';
 
+import { Example, Info } from '../../utils/example';
 import WeaveCloudLogo from '.';
 
 export default function WeaveCloudLogoExample() {
   return (
     <div>
-      <p>Dark Logo</p>
-      <div>
+      <Example>
+        <Info>Dark Logo</Info>
         <WeaveCloudLogo theme="dark" />
-      </div>
-      <p>Light Logo</p>
-      <div style={{backgroundColor: 'black'}}>
-        <WeaveCloudLogo theme="light" />
-      </div>
+      </Example>
+      <Example>
+        <Info>Light Logo</Info>
+        <div style={{backgroundColor: 'black'}}>
+          <WeaveCloudLogo theme="light" />
+        </div>
+      </Example>
     </div>
   );
 }


### PR DESCRIPTION
This PR makes all the examples use `<Example />` to separate samples. It will allow us to properly introduce the JSX alongside the rendered output in #114.