### PR TITLE
Show time in UTC format in PrometheusGraph tooltip

### DIFF
--- a/src/components/PrometheusGraph/_DeploymentAnnotations.js
+++ b/src/components/PrometheusGraph/_DeploymentAnnotations.js
@@ -48,8 +48,7 @@ const formattedDeployments = ({ deployments, timeScale }) => (
     return {
       key: `${Data} --- ${Stamp}`,
       position: timeScale(moment(Stamp).unix()),
-      // TODO: Consider changing the timestamp to a more standard format.
-      humanizedTimestamp: new Date(Stamp).toUTCString(),
+      timestamp: Stamp,
       serviceIDs,
       action,
     };
@@ -100,7 +99,7 @@ class DeploymentAnnotations extends React.PureComponent {
         {hoveredDeployment && (
           <Tooltip
             graphWidth={chartWidth}
-            humanizedTimestamp={hoveredDeployment.humanizedTimestamp}
+            timestamp={hoveredDeployment.timestamp}
             x={hoveredDeployment.position}
             y={chartHeight}
           >

--- a/src/components/PrometheusGraph/_HoverInfo.js
+++ b/src/components/PrometheusGraph/_HoverInfo.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { map, max } from 'lodash';
@@ -65,8 +66,7 @@ class HoverInfo extends React.PureComponent {
     // Render focused circle last so that it stands out.
     const sortedHoverPoints = [...filteredHoverPoints].sort(p => (p.focused ? 1 : -1));
 
-    // TODO: Consider changing the timestamp to a more standard format.
-    const timestamp = new Date(1000 * this.props.timestampSec).toUTCString();
+    const timestamp = moment.unix(this.props.timestampSec);
 
     // We want to have same formatting (precision, units, etc...) across
     // all tooltip values so we create a formatter for a reference value
@@ -87,7 +87,7 @@ class HoverInfo extends React.PureComponent {
             />
           ))}
         </HoverLine>
-        <Tooltip x={mouseX} y={mouseY} graphWidth={chartWidth} humanizedTimestamp={timestamp}>
+        <Tooltip x={mouseX} y={mouseY} graphWidth={chartWidth} timestamp={timestamp}>
           {filteredHoverPoints.map(datapoint => (
             <TooltipRow key={datapoint.key} focused={datapoint.focused}>
               <TooltipRowColor color={datapoint.color} />

--- a/src/components/PrometheusGraph/_Tooltip.js
+++ b/src/components/PrometheusGraph/_Tooltip.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -8,11 +9,11 @@ const TooltipContainer = styled.div.attrs({
   // generation every time the tooltip is repositioned.
   style: ({ x, y }) => ({ left: x, top: y }),
 })`
+  color: ${props => props.theme.colors.primary.charcoal};
   background-color: ${props => props.theme.colors.lightgray};
   border: 1px solid ${props => props.theme.colors.neutral.lightgray};
-  border-radius: 4px;
+  border-radius: ${props => props.theme.borderRadius};
   padding: 10px 15px;
-  color: #555;
   position: absolute;
   margin-top: 20px;
   margin-left: 10px;
@@ -24,8 +25,9 @@ const TooltipContainer = styled.div.attrs({
 `;
 
 const Timestamp = styled.div`
+  font-family: "Roboto", sans-serif;
   font-size: 13px;
-  margin-bottom: 5px;
+  margin-bottom: 8px;
 `;
 
 class Tooltip extends React.PureComponent {
@@ -40,13 +42,13 @@ class Tooltip extends React.PureComponent {
   }
 
   render() {
-    const { x, y, humanizedTimestamp, graphWidth } = this.props;
+    const { x, y, timestamp, graphWidth } = this.props;
     const tooltipWidth = this.getTooltipBoundingRect().width;
     const clampedX = Math.min(x, graphWidth - tooltipWidth - 10);
 
     return (
       <TooltipContainer x={clampedX} y={y} innerRef={this.saveTooltipRef}>
-        <Timestamp>{humanizedTimestamp}</Timestamp>
+        <Timestamp>{moment(timestamp).utc().format()} UTC</Timestamp>
         {this.props.children}
       </TooltipContainer>
     );


### PR DESCRIPTION
Fixes https://github.com/weaveworks/service-ui/issues/743.

The timestamp format is uglier (less humanized), but at least it's consistent with how Time Travel control shows it. We should probably decide on a better cross-app time format, but that's a separate issue (cc @bia).

![image](https://user-images.githubusercontent.com/1216874/36199723-b32ee446-117a-11e8-9d46-a572f5bb7f88.png)

