### PR TITLE
Add support for groups in dropdown

### DIFF
--- a/src/components/Dropdown/example.js
+++ b/src/components/Dropdown/example.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Example } from '../../utils/example';
+import { Example, Info } from '../../utils/example';
 import Dropdown from '.';
 
 const items = [
@@ -15,6 +15,41 @@ const items = [
   {
     value: 'third-thing',
     label: 'Super long thing, this should get truncated',
+  },
+];
+
+const groups = [
+  [
+    {
+      value: 'a-first',
+      label: 'A: First Thing',
+    },
+    {
+      value: 'a-second',
+      label: 'A: Second Thing',
+    },
+  ],
+  [
+    {
+      value: 'b-first',
+      label: 'B: First Thing',
+    },
+    {
+      value: 'b-second',
+      label: 'B: Second Thing',
+    },
+  ],
+];
+
+const divided = [
+  {
+    value: 'c-first',
+    label: 'C: First Thing',
+  },
+  null,
+  {
+    value: 'd-first',
+    label: 'D: First Thing',
   },
 ];
 
@@ -34,7 +69,16 @@ export default class DropdownExample extends React.Component {
     return (
       <div>
         <Example>
+          <Info>Default dropdown</Info>
           <Dropdown items={items} value={this.state.selected} onChange={onChange} />
+        </Example>
+        <Example>
+          <Info>Grouped items (passed as subarrays)</Info>
+          <Dropdown items={groups} value={this.state.selected} onChange={onChange} />
+        </Example>
+        <Example>
+          <Info>Grouped items (with null as dividers)</Info>
+          <Dropdown items={divided} value={this.state.selected} onChange={onChange} />
         </Example>
       </div>
     );


### PR DESCRIPTION
This also re-adds the padding in the wrapper as well as margins the
divider for balanced whitespace.

![uicomponents-dropdown-divider-whitespace](https://user-images.githubusercontent.com/32963/36292493-1fd442c6-12ca-11e8-8f89-4f493c2dc458.png)

