### PR TITLE
Add support for PrometheusGraph legend Ctrl+click multiselect

### DIFF
--- a/src/components/PrometheusGraph/_DeploymentAnnotations.js
+++ b/src/components/PrometheusGraph/_DeploymentAnnotations.js
@@ -48,7 +48,7 @@ const formattedDeployments = ({ deployments, timeScale }) => (
     return {
       key: `${Data} --- ${Stamp}`,
       position: timeScale(moment(Stamp).unix()),
-      timestamp: Stamp,
+      timestamp: moment(Stamp).format(),
       serviceIDs,
       action,
     };

--- a/src/components/PrometheusGraph/_HoverInfo.js
+++ b/src/components/PrometheusGraph/_HoverInfo.js
@@ -66,7 +66,7 @@ class HoverInfo extends React.PureComponent {
     // Render focused circle last so that it stands out.
     const sortedHoverPoints = [...filteredHoverPoints].sort(p => (p.focused ? 1 : -1));
 
-    const timestamp = moment.unix(this.props.timestampSec);
+    const timestamp = moment.unix(this.props.timestampSec).format();
 
     // We want to have same formatting (precision, units, etc...) across
     // all tooltip values so we create a formatter for a reference value

--- a/src/components/PrometheusGraph/_Tooltip.js
+++ b/src/components/PrometheusGraph/_Tooltip.js
@@ -57,7 +57,7 @@ class Tooltip extends React.PureComponent {
 
 Tooltip.propTypes = {
   graphWidth: PropTypes.number.isRequired,
-  humanizedTimestamp: PropTypes.string.isRequired,
+  timestamp: PropTypes.string.isRequired,
   x: PropTypes.number.isRequired,
   y: PropTypes.number.isRequired,
 };


### PR DESCRIPTION
Resolves https://github.com/weaveworks/service-ui/issues/1433.

![image](https://user-images.githubusercontent.com/1216874/36498059-80c4aa18-173d-11e8-9025-f072948d04cd.png)

##### Changes

* Added graph legend multiselect support via <kbd>Ctrl</kbd> + click.
* Introduced `multiSeriesByKey` in `prepareMultiSeries` for more correct calculations (if the initial list of multi-series is not sorted, we couldn't rely on the order, so we need keys instead of indices).
* Fixed the warning for wrong `timestamp` format forwarded to `_Tooltip` subcomponent.
* Added `propTypes` to `_Chart` private subcomponent.
