### PR TITLE
Display errors in PrometheusGraph component

### DIFF
--- a/src/components/PrometheusGraph/PrometheusGraph.js
+++ b/src/components/PrometheusGraph/PrometheusGraph.js
@@ -25,6 +25,7 @@ import { stack } from 'd3-shape';
 
 import Chart from './_Chart';
 import AxesGrid from './_AxesGrid';
+import ErrorOverlay from './_ErrorOverlay';
 import LoadingOverlay from './_LoadingOverlay';
 import DeploymentAnnotations from './_DeploymentAnnotations';
 import HoverInfo from './_HoverInfo';
@@ -373,7 +374,7 @@ class PrometheusGraph extends React.PureComponent {
   render() {
     const {
       yAxisLabel, deployments, metricUnits, showStacked, simpleTooltip,
-      legendShown, legendCollapsable, loading,
+      legendShown, legendCollapsable, loading, error,
     } = this.props;
     const {
       selectedLegendMultiSeriesKeys, hoveredLegendSeriesKey, chartWidth, chartHeight,
@@ -437,6 +438,11 @@ class PrometheusGraph extends React.PureComponent {
           onHoveredSeriesChange={this.handleHoveredLegendSeriesChange}
           multiSeries={multiSeries}
         />
+        <ErrorOverlay
+          hasData={hasData}
+          loading={loading}
+          error={error}
+        />
         <LoadingOverlay
           loading={loading}
         />
@@ -490,6 +496,10 @@ PrometheusGraph.propTypes = {
    * If true, shows a loading overlay on top of the graph
    */
   loading: PropTypes.bool,
+  /**
+   * If set, shows the error message over the graph
+   */
+  error: PropTypes.string,
   /**
    * Making graph legend section collapsable
    */

--- a/src/components/PrometheusGraph/_ErrorOverlay.js
+++ b/src/components/PrometheusGraph/_ErrorOverlay.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const ErrorContainer = styled.div`
+  color: ${props => props.theme.colors.status.error};
+  opacity: ${props => (props.loading ? 0.2 : 1)};
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  padding-top: 95px;
+  box-sizing: border-box;
+  text-align: center;
+`;
+
+const ErrorText = styled.span`
+  border-radius: ${props => props.theme.borderRadius};
+  padding: 5px 10px;
+  opacity: 0.75;
+
+  ${props => props.hasData && `
+    background-color: ${props.theme.colors.neutral.white};
+  `}
+`;
+
+class ErrorOverlay extends React.PureComponent {
+  render() {
+    const { loading, error, hasData } = this.props;
+    if (!error) return null;
+
+    return (
+      <ErrorContainer loading={loading}>
+        <ErrorText hasData={hasData}>
+          {error}
+        </ErrorText>
+      </ErrorContainer>
+    );
+  }
+}
+
+ErrorOverlay.propTypes = {
+  hasData: PropTypes.bool.isRequired,
+  loading: PropTypes.bool.isRequired,
+  error: PropTypes.string,
+};
+
+export default ErrorOverlay;

--- a/src/components/PrometheusGraph/_LoadingOverlay.js
+++ b/src/components/PrometheusGraph/_LoadingOverlay.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 import CircularProgress from '../CircularProgress';
@@ -25,5 +26,9 @@ class LoadingOverlay extends React.PureComponent {
     );
   }
 }
+
+LoadingOverlay.propTypes = {
+  loading: PropTypes.bool.isRequired,
+};
 
 export default LoadingOverlay;

--- a/src/components/PrometheusGraph/example.js
+++ b/src/components/PrometheusGraph/example.js
@@ -77,7 +77,6 @@ export default class PrometheusGraphExample extends React.Component {
             startTimeSec={this.state.startTime}
             endTimeSec={this.state.endTime}
             deployments={this.state.deployments}
-            getSeriesName={({ metric }) => metric.namespace}
           />
           <Info>Reloading graph</Info>
           <PrometheusGraph
@@ -87,7 +86,27 @@ export default class PrometheusGraphExample extends React.Component {
             stepDurationSec={this.state.stepDuration}
             startTimeSec={this.state.startTime}
             endTimeSec={this.state.endTime}
-            getSeriesName={({ metric }) => metric.namespace}
+            deployments={this.state.deployments}
+          />
+          <Info>Error with no data</Info>
+          <PrometheusGraph
+            showStacked
+            multiSeries={[]}
+            error="No datapoints found. Maybe the metric does not exist?"
+            loading={this.state.loading}
+            stepDurationSec={this.state.stepDuration}
+            startTimeSec={this.state.startTime}
+            endTimeSec={this.state.endTime}
+          />
+          <Info>Error with data</Info>
+          <PrometheusGraph
+            showStacked
+            multiSeries={this.state.multiSeriesServices}
+            error="Hmm... something with the metrics looks wrong"
+            loading={this.state.loading}
+            stepDurationSec={this.state.stepDuration}
+            startTimeSec={this.state.startTime}
+            endTimeSec={this.state.endTime}
           />
         </Example>
       </div>


### PR DESCRIPTION
Resolves #142.

Currently, graph errors in Service UI dashboards & notebooks are rendered prior to the _PrometheusGraph_ component, but it makes more sense to have that logic inside the component.

One issue this will also solve is not showing the (re)loader if the error message was displayed - now we show the loader overlay on top of the error overlay.

##### Screenshots from examples

![image](https://user-images.githubusercontent.com/1216874/37088612-42fa327c-21fe-11e8-90a1-bcdb94bc53f9.png)

![image](https://user-images.githubusercontent.com/1216874/37088626-4d6793e4-21fe-11e8-8399-a537e1363824.png)

