### PR TITLE
promgraph: Put max-width on legend text to avoid overflowing the page

### DIFF
--- a/src/components/PrometheusGraph/_Legend.js
+++ b/src/components/PrometheusGraph/_Legend.js
@@ -27,7 +27,6 @@ const LegendItem = styled.div`
   margin-right: 2px;
   margin-bottom: 2px;
   border-radius: 4px;
-  max-width: 45%;
 
   &:hover {
     background-color: ${props => props.theme.colors.athens};
@@ -42,6 +41,7 @@ const LegendItemName = styled.span`
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
+  max-width: 36ch;
 `;
 
 const LegendToggle = styled.span`


### PR DESCRIPTION
With very large legend text, the layout engine tries to cram as much text as
possible before giving up and ellipsising.

Instead of constraining the legend item to 45% of allocated width, we push down
max-width to the text itself so we have a limit there.
