### PR TITLE
Shifting turquoise to a darker AA compliant shade

### DIFF
--- a/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/src/components/Button/__snapshots__/Button.test.js.snap
@@ -55,7 +55,7 @@ exports[`<Button /> snapshots renders danger 1`] = `
 .c0:hover {
   -webkit-transition: color .3s ease;
   transition: color .3s ease;
-  background: #861935;
+  background: #b12146;
   color: #fff;
 }
 
@@ -144,7 +144,7 @@ exports[`<Button /> snapshots renders primary 1`] = `
   border: 0;
   outline: none;
   box-shadow: 0 1px 3px rgba(0,0,0,0.12),0 1px 2px rgba(0,0,0,0.24);
-  background: #00bcd4;
+  background: #037aa9;
   color: #fff;
   font-size: 0.875em;
   text-transform: uppercase;
@@ -154,7 +154,7 @@ exports[`<Button /> snapshots renders primary 1`] = `
 .c0:hover {
   -webkit-transition: color .3s ease;
   transition: color .3s ease;
-  background: #007888;
+  background: #036890;
   color: #fff;
 }
 

--- a/src/theme/weave.js
+++ b/src/theme/weave.js
@@ -18,7 +18,7 @@ const colors = {
   lightgray: '#f8f8f8',
   sand: '#f5f4f4',
   stratos: '#001755',
-  turquoise: '#00bcd4',
+  turquoise: '#037aa9',
   white: '#fff',
   // more legacy
   alabaster: '#fcfcfc',
@@ -173,13 +173,13 @@ const weave = {
         color: colors.white,
         background: colors.turquoise,
         hoverColor: colors.white,
-        hoverBackground: darken(0.15, colors.turquoise),
+        hoverBackground: darken(0.05, colors.turquoise),
       },
       danger: {
         color: colors.white,
         background: colors.status.error,
         hoverColor: colors.white,
-        hoverBackground: darken(0.15, colors.status.error),
+        hoverBackground: darken(0.05, colors.status.error),
       },
       disabled: {
         color: colors.gray,


### PR DESCRIPTION
Shifting ![](https://placehold.it/15/00bcd4/000000?text=+) _turquoise_  a little darker to ![](https://placehold.it/15/037aa9/000000?text=+) _#037AA9_ because this colour passes WCAG AA both as a background with white text and as colored text on a ![](https://placehold.it/15/fafafc/000000?text=+) _whitesmoke_ background.

Completes #161.