### PR TITLE
Merge neutral theme colors

### DIFF
--- a/docs/js/Example.js
+++ b/docs/js/Example.js
@@ -41,7 +41,7 @@ const TableHeader = styled.tr`
   border-bottom: 1px solid ${props => props.theme.colors.gray};
 
   th {
-    color: ${props => props.theme.colors.lavender};
+    color: ${props => props.theme.colors.primary.lavender};
     font-size: 12px;
     font-weight: normal;
     text-transform: uppercase;

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -18,7 +18,7 @@ const Item = styled.div`
 const Popover = styled.div`
   position: absolute;
   background-color: ${props => props.theme.colors.white};
-  border: 1px solid ${props => props.theme.colors.neutral.lightgray};
+  border: 1px solid ${props => props.theme.colors.silverDark};
   border-radius: ${props => props.theme.borderRadius};
   z-index: 3;
   box-shadow: ${props => props.theme.boxShadow.light};
@@ -49,13 +49,13 @@ const ItemWrapper = Item.extend`
 
 const Divider = styled.div`
   margin: 6px 0;
-  border-bottom: 1px solid ${props => props.theme.colors.neutral.lightgray};
+  border-bottom: 1px solid ${props => props.theme.colors.silverDark};
 `;
 
 const SelectedItem = Item.extend`
   border-radius: ${props => props.theme.borderRadius};
-  background-color: ${props => props.theme.colors.neutral.white};
-  border: 1px solid ${props => props.theme.colors.neutral.gray};
+  background-color: ${props => props.theme.colors.white};
+  border: 1px solid ${props => props.theme.colors.dustyGray};
   display: flex;
 
   ${Item} {

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -30,12 +30,12 @@ const StyledInput = component => styled(component)`
   display: inline-block;
 
   input {
-    ${props => placeholder(props.theme.colors.neutral.gray)};
+    ${props => placeholder(props.theme.colors.dustyGray)};
     display: inline-block;
     padding: 0 12px;
     line-height: 36px;
     box-shadow: none;
-    border: 1px solid ${props => props.theme.colors.neutral.gray};
+    border: 1px solid ${props => props.theme.colors.dustyGray};
     border-radius: ${props => props.theme.borderRadius};
   }
 `;

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 const MenuWrapper = styled.div`
-  color: ${props => props.theme.colors.lavender};
+  color: ${props => props.theme.colors.primary.lavender};
   text-align: left;
 `;
 

--- a/src/components/Menu/MenuItem.js
+++ b/src/components/Menu/MenuItem.js
@@ -25,7 +25,7 @@ const Item = styled.div`
 
   ${props => props.active && `
     color: ${props.theme.colors.sand};
-    background-color: ${props.theme.colors.lavender};
+    background-color: ${props.theme.colors.primary.lavender};
   `};
 `;
 

--- a/src/components/PrometheusGraph/PrometheusGraph.js
+++ b/src/components/PrometheusGraph/PrometheusGraph.js
@@ -90,7 +90,7 @@ const GraphContainer = styled.div`
 `;
 
 const AxisLabel = styled.span`
-  color: ${props => props.theme.colors.neutral.black};
+  color: ${props => props.theme.colors.black};
   font-size: ${props => props.theme.fontSizes.normal};
   opacity: ${props => (props.loading ? 0.35 : 1)};
   transform: translate(-60px, 165px) rotate(-90deg);

--- a/src/components/PrometheusGraph/_ErrorOverlay.js
+++ b/src/components/PrometheusGraph/_ErrorOverlay.js
@@ -21,7 +21,7 @@ const ErrorText = styled.span`
   opacity: 0.75;
 
   ${props => props.hasData && `
-    background-color: ${props.theme.colors.neutral.white};
+    background-color: ${props.theme.colors.white};
   `}
 `;
 

--- a/src/components/PrometheusGraph/_Legend.js
+++ b/src/components/PrometheusGraph/_Legend.js
@@ -9,7 +9,7 @@ const LegendContainer = styled.div`
 `;
 
 const LegendItems = styled.div`
-  color: ${props => props.theme.colors.neutral.black};
+  color: ${props => props.theme.colors.black};
   box-sizing: border-box;
   display: flex;
   flex-wrap: wrap;
@@ -45,7 +45,7 @@ const LegendItemName = styled.span`
 `;
 
 const LegendToggle = styled.span`
-  color: ${props => props.theme.colors.lavender};
+  color: ${props => props.theme.colors.primary.lavender};
   cursor: pointer;
   display: block;
   padding: 5px;

--- a/src/components/PrometheusGraph/_Tooltip.js
+++ b/src/components/PrometheusGraph/_Tooltip.js
@@ -11,7 +11,7 @@ const TooltipContainer = styled.div.attrs({
 })`
   color: ${props => props.theme.colors.primary.charcoal};
   background-color: ${props => props.theme.colors.lightgray};
-  border: 1px solid ${props => props.theme.colors.neutral.lightgray};
+  border: 1px solid ${props => props.theme.colors.silverDark};
   border-radius: ${props => props.theme.borderRadius};
   padding: 10px 15px;
   position: absolute;

--- a/src/components/TimeTravel/TimeTravel.js
+++ b/src/components/TimeTravel/TimeTravel.js
@@ -31,8 +31,8 @@ const TimeControlsWrapper = styled.div`
 `;
 
 const TimeControlsContainer = styled.div`
-  border: 1px solid ${props => props.theme.colors.neutral.lightgray};
-  box-shadow: 0 0 2px ${props => props.theme.colors.neutral.lightgray};
+  border: 1px solid ${props => props.theme.colors.silverDark};
+  box-shadow: 0 0 2px ${props => props.theme.colors.silverDark};
   background-color: ${props => props.theme.colors.white};
   border-radius: 5px;
   display: flex;

--- a/src/components/TimeTravel/_LiveModeToggle.js
+++ b/src/components/TimeTravel/_LiveModeToggle.js
@@ -10,7 +10,7 @@ const LiveModeToggleWrapper = styled.div`
 const ToggleButton = styled.button`
   border: 0;
   background-color: transparent;
-  border-right: 1px solid ${props => props.theme.colors.neutral.lightgray};
+  border-right: 1px solid ${props => props.theme.colors.silverDark};
   color: ${props => props.theme.colors.primary.charcoal};
   font-size: 14px;
   padding: 2px 8px;
@@ -23,7 +23,7 @@ const ToggleButton = styled.button`
   &:focus { outline: none; }
 
   ${props => props.pressed && `
-    box-shadow: inset 1px 1px 6px ${props.theme.colors.neutral.lightgray};
+    box-shadow: inset 1px 1px 6px ${props.theme.colors.silverDark};
     color: ${props.theme.colors.gray};
     opacity: 0.75;
   `}

--- a/src/components/TimeTravel/_RangeSelector.js
+++ b/src/components/TimeTravel/_RangeSelector.js
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 const HEIGHT_PX = 27;
 
 const RangeSelectorWrapper = styled.div`
-  border-left: 1px solid ${props => props.theme.colors.neutral.lightgray};
+  border-left: 1px solid ${props => props.theme.colors.silverDark};
   min-width: 75px;
 `;
 
@@ -36,8 +36,8 @@ const RangeOptionsListWrapper = styled.div`
 `;
 
 const RangeOptionsList = styled.div`
-  background-color: ${props => props.theme.colors.neutral.white};
-  border: 1px solid ${props => props.theme.colors.neutral.lightgray};
+  background-color: ${props => props.theme.colors.white};
+  border: 1px solid ${props => props.theme.colors.silverDark};
   color: ${props => props.theme.colors.primary.charcoal};
   box-sizing: border-box;
   position: absolute;

--- a/src/theme/weave.js
+++ b/src/theme/weave.js
@@ -1,33 +1,17 @@
 import { darken } from 'polished';
 import { isString, kebabCase, forEach } from 'lodash';
 
-const neutral = {
-  black: '#1a1a1a',
-  gray: '#9a9a9a',
-  lightgray: '#c1c1c1',
-  white: '#fff',
-};
-
 const colors = {
-  // legacy
-  athens: '#e2e2ec',
-  black: '#000',
-  gray: '#aaaaaa',
-  gunpowder: '#3c3c5b',
-  lavender: '#8383ac',
-  lightgray: '#f8f8f8',
-  sand: '#f5f4f4',
-  stratos: '#001755',
-  turquoise: '#037aa9',
-  white: '#fff',
-  // more legacy
+  // uncategorized colors
   alabaster: '#fcfcfc',
   aliceBlue: '#f0f8ff',
   alto: '#ddd',
   amethystSmoke: '#9292b7',
   armadillo: '#393a34',
+  athens: '#e2e2ec',
   athensGray: '#eeeef4',
   athensGrayDark: '#e9e9f1',
+  black: '#1a1a1a',
   blueHaze: '#c0c0d5',
   chetwodeBlue: '#8f8fd7',
   comet: '#5b5b88',
@@ -39,8 +23,11 @@ const colors = {
   eastBay: '#4a5d87',
   fog: '#ddddff',
   gallery: '#eee',
+  gray: '#aaaaaa',
+  gunpowder: '#3c3c5b',
   kimberly: '#7d7da8',
   kimberlyDark: '#656597',
+  lightgray: '#f8f8f8',
   linkWater: '#d7ecf5',
   logan: '#b1b1cb',
   mercury: '#e8e8e8',
@@ -49,13 +36,18 @@ const colors = {
   mulledWine: '#46466a',
   mystic: '#dae4ea',
   olivine: '#a0be7e',
+  sand: '#f5f4f4',
   silver: '#ccc',
+  silverDark: '#c1c1c1',
   snuff: '#dadaea',
   solidGray: '#808080',
+  stratos: '#001755',
   titanWhite: '#eeeeff',
   tundora: '#444',
+  turquoise: '#037aa9',
   veniceBlue: '#065f7d',
   whisper: '#fdfdfe',
+  white: '#fff',
   whiteLilac: '#f0f0fa',
   whiteSmoke: '#fafafc',
   promQL: {
@@ -92,7 +84,6 @@ const colors = {
     info: '#049cd7', // blue
     disabled: '#9a9a9a',
   },
-  neutral,
   // Used by PrometheusGraph component
   graphThemes: {
     blue: [
@@ -141,7 +132,7 @@ const colors = {
 const weave = {
   colors,
 
-  textColor: colors.neutral.black,
+  textColor: colors.black,
 
   fontSizes: {
     normal: '0.875em',
@@ -155,7 +146,7 @@ const weave = {
     none: 'none',
     light: '0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24)',
     heavy: '0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23)',
-    selected: `0px 0px 2px 2px ${colors.lavender}`,
+    selected: `0px 0px 2px 2px ${colors.primary.lavender}`,
   },
 
   borderRadius: '4px',

--- a/styleguide/Colors.js
+++ b/styleguide/Colors.js
@@ -133,9 +133,7 @@ class Colors extends React.Component {
         <Row>{this.renderSwatches(theme.colors.accent)}</Row>
         <Text large>Status Colors</Text>
         <Row>{this.renderSwatches(theme.colors.status)}</Row>
-        <Text large>Neutral Colors</Text>
-        <Row>{this.renderSwatches(theme.colors.neutral)}</Row>
-        <Text large>Legacy Colors</Text>
+        <Text large>Uncategorized Colors</Text>
         <Row>{this.renderSwatches(theme.colors)}</Row>
         <Text large>PromQL Colors</Text>
         <Row>{this.renderSwatches(theme.colors.promQL)}</Row>


### PR DESCRIPTION
As discussed with @bia, the grays are not really the _neutral_ colors anymore as the whole theme weighs in direction of purple hues. Removing this category for now and gathering all the grays in one place will help us consolidate the theme and get rid of redundant/similar shades of gray.

##### Changes

* Removed `neutral.white` (as it's already available under `white` `#ffffff`)
* Moved `neutral.lightgray` into `silverDark` `#c1c1c1`
* Referring to `dustyGray` `#969696` instead of `neutral.gray` `#9a9a9a`
* Referring to `black` (changed from `#000000` to `#1a1a1a`) instead of `neutral.black`
* Referring to `primary.lavender` instead of `lavender`
* Removed `neutral` theme colors category
