### PR TITLE
Add DataTable component

### DIFF
--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -1,0 +1,252 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { map, orderBy, get, first } from 'lodash';
+import { transparentize } from 'polished';
+
+import { copyPropTypes } from '../../utils/compose';
+
+import Header from './_Header';
+
+const borderColor = props => transparentize(0.6, props.theme.colors.mischka);
+
+const Styled = component => styled(component)`
+  border-collapse: collapse;
+  width: 100%;
+  /* Any column that doesn't specify a width explicitly will share the */
+  /* remaining horizontal space. */
+  table-layout: fixed;
+
+  td {
+    padding: 10px 8px;
+    vertical-align: top;
+    border-left: 1px solid ${borderColor};
+  }
+
+  thead td {
+    border: 0;
+    font-weight: bold;
+  }
+
+  thead,
+  tbody {
+    border-bottom: 1px solid ${borderColor};
+    border-left: 3px solid transparent;
+  }
+`;
+
+// Split this into a helper to keep the `doSort` method consistent with the initial state `sort`.
+const sort = (data, key, order) => orderBy(data, key, [order]);
+
+/**
+ *  A sortable table for showing large data sets.
+ *  ```javascript
+ *
+ *  const data = [
+ *  {
+ *    name: 'Bob',
+ *    email: 'a@weave.works',
+ *  },
+ *  {
+ *    name: 'Albert',
+ *    email: 'b@weave.works',
+ *  },
+ * ];
+ *
+ *  React.render(
+ *   <DataTable
+ *    data={data}
+ *    columns={[{ value: 'name', label: 'Name' }, { value: 'email', label: 'Email' }]}
+ *   >
+ *    {rows =>
+ *      map(rows, r => (
+ *        <tr key={r.email}>
+ *          <td>{r.name}</td>
+ *          <td>{r.email}</td>
+ *        </tr>
+ *      ))
+ *    }
+ *   </DataTable>
+ * )
+ * ```
+ *
+ * #### Nested table
+ * ```javascript
+ * const nesteData = [
+ *   {
+ *     workloadId: 'default:deployment/myworkload',
+ *     containers: [
+ *       { name: 'nginx', behind: '4' },
+ *       { name: 'redis', behind: '1' },
+ *       { name: 'envoy', behind: '2' },
+ *     ],
+ *   },
+ *   {
+ *     workloadId: 'default:deployment/helloworld',
+ *     containers: [{ name: 'helloworld', behind: '2' }],
+ *   },
+ *  ];
+ *
+ *  <DataTable
+ *   nested
+ *   data={nesteData}
+ *   sortBy="workloadId"
+ *   sortOrder="asc"
+ *   columns={[
+ *     { value: 'workloadId', label: 'Workload' },
+ *     { value: 'containers', label: 'Containers' },
+ *     { value: 'behind', label: 'Behind' },
+ *   ]}
+ *   sortOverrides={{ behind: row => max(map(row.containers, c => c.behind)) }}
+ * >
+ *   {rows =>
+ *     map(rows, r => (
+ *       <tbody key={r.workloadId}>
+ *         {map(r.containers, (c, i) => (
+ *           <tr key={c.name}>
+ *             {i === 0 && <td rowSpan={r.containers.length}>{r.workloadId}</td>}
+ *             <td>{c.name}</td>
+ *             <td>{c.behind}</td>
+ *           </tr>
+ *         ))}
+ *       </tbody>
+ *     ))
+ *   }
+ * </DataTable>
+ * ```
+ *
+ */
+class DataTable extends React.PureComponent {
+  state = {
+    sortField: this.props.sortBy || get(first(this.props.columns), 'value'),
+    sortOrder: this.props.sortOrder,
+    sortedData: sort(this.props.data, this.props.sortBy, this.props.sortOrder),
+  };
+
+  componentDidMount() {
+    this.doSort(this.state.sortedData, this.state.sortField, this.state.sortOrder);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { sortOrder, sortField } = this.state;
+    let field = sortField;
+    let order = sortOrder;
+
+    if (nextProps !== this.props) {
+      // Only translate if props have *actually* changed.
+      if (nextProps.sortBy !== this.props.sortBy || nextProps.sortOrder !== this.props.sortOrder) {
+        field = nextProps.sortBy;
+        order = nextProps.sortOrder;
+      }
+
+      this.doSort(nextProps.data, field, order);
+    }
+  }
+
+  doSort = (data, sortField, sortOrder = 'asc') => {
+    const { sortOverrides } = this.props;
+
+    this.setState({
+      sortField,
+      sortOrder,
+      sortedData:
+        // User overrides if specified, else do the default sort
+        sortOverrides && sortOverrides[sortField]
+          ? orderBy(data, sortOverrides[sortField], sortOrder)
+          : sort(data, sortField, sortOrder),
+    });
+  };
+
+  handleHeaderClick = (ev, column) => {
+    let order;
+    let field = this.state.sortField;
+
+    const isCurrentColumn = column === this.state.sortField;
+    if (isCurrentColumn) {
+      // If we are already sorting by this column, change the order.
+      order = this.state.sortOrder === 'asc' ? 'desc' : 'asc';
+    } else {
+      // Else, order by the new column, ascending
+      order = 'asc';
+      field = column;
+    }
+
+    this.doSort(this.state.sortedData, field, order);
+  };
+
+  render() {
+    const { className, children, columns, nested } = this.props;
+    const { sortedData, sortOrder, sortField } = this.state;
+
+    return (
+      <table className={className}>
+        <thead>
+          <tr>
+            {map(columns, ({ value, label, sortable }) => (
+              <Header
+                sortable={sortable}
+                order={sortField === value ? sortOrder : null}
+                value={value}
+                onClick={this.handleHeaderClick}
+                key={value}
+              >
+                {label}
+              </Header>
+            ))}
+          </tr>
+        </thead>
+        {/* Don't render the tbody if nested; nested tables use <tbody> for rows */}
+        {nested ? children(sortedData) : <tbody>{children(sortedData)}</tbody>}
+      </table>
+    );
+  }
+}
+
+const columnPropType = PropTypes.shape({
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  label: PropTypes.string,
+});
+
+DataTable.propTypes = {
+  /**
+   * The rows that will be sorted by clicking on the headers.
+   * There must be a key in your row object that matches the column `value`.
+   */
+  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  /**
+   * A render-prop function that will be passed the sorted rows for the table.
+   */
+  children: PropTypes.func.isRequired,
+  /**
+   * An array of objects that will be used as columns.
+   * `value` must map to a key in your data in order for sorting to work.
+   */
+  columns: PropTypes.arrayOf(columnPropType).isRequired,
+  /**
+   * The value by which to sort the rows passed to the `data` prop.
+   */
+  sortBy: PropTypes.string,
+  /**
+   * Whether to sort by 'asc' or 'desc' on initial load.
+   * Modifying this prop will override the user's currently selected sort order.
+   */
+  sortOrder: PropTypes.oneOf(['asc', 'desc']),
+  /**
+   * A map of customer sorting functions that will be used when a column is sorted.
+   * They keys of this object should match the colum `values` that to which you wish to
+   * provide customer sorting logic.
+   *
+   */
+  sortOverrides: PropTypes.object,
+  /**
+   * If true, a wrapping `<tbody />` element will NOT be rendered.
+   * All child rows of `nested` tables should be <tbody /> tags
+   */
+  nested: PropTypes.bool,
+};
+
+DataTable.defaultProps = {
+  sortOrder: 'asc',
+};
+
+export default copyPropTypes(DataTable, Styled(DataTable));

--- a/src/components/DataTable/DataTable.test.js
+++ b/src/components/DataTable/DataTable.test.js
@@ -1,0 +1,218 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { map } from 'lodash';
+import renderer from 'react-test-renderer';
+import 'jest-styled-components';
+
+import { withTheme } from '../../utils/theme';
+
+import DataTable from '.';
+
+const getFirstRowName = table =>
+  table
+    .find('tbody tr')
+    .first()
+    .find('td')
+    .first()
+    .text();
+
+describe('DataTable', () => {
+  const data = [
+    {
+      name: 'Bob',
+      email: 'a@weave.works',
+    },
+    {
+      name: 'Albert',
+      // Notice the emails are inverted to test sorting by this field
+      email: 'b@weave.works',
+    },
+    {
+      name: 'Ty',
+      email: 'c@weave.works',
+    },
+  ];
+
+  describe('snapshots', () => {
+    it('renders rows', () => {
+      const tree = renderer
+        .create(
+          withTheme(
+            <DataTable
+              data={data}
+              columns={[{ value: 'name', label: 'Name' }, { value: 'email', label: 'Email' }]}
+            >
+              {rows =>
+                map(rows, r => (
+                  <tr key={r.email}>
+                    <td>{r.name}</td>
+                    <td>{r.email}</td>
+                  </tr>
+                ))
+              }
+            </DataTable>
+          )
+        )
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+    it('sorts rows by a field', () => {
+      const tree = renderer
+        .create(
+          withTheme(
+            <DataTable
+              data={data}
+              sortBy="email"
+              columns={[{ value: 'name', label: 'Name' }, { value: 'email', label: 'Email' }]}
+            >
+              {rows =>
+                map(rows, r => (
+                  <tr key={r.email}>
+                    <td>{r.name}</td>
+                    <td>{r.email}</td>
+                  </tr>
+                ))
+              }
+            </DataTable>
+          )
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+    it('sorts fields by a give order', () => {
+      const tree = renderer
+        .create(
+          withTheme(
+            <DataTable
+              data={data}
+              sortBy="email"
+              sortOrder="desc"
+              columns={[{ value: 'name', label: 'Name' }, { value: 'email', label: 'Email' }]}
+            >
+              {rows =>
+                map(rows, r => (
+                  <tr key={r.email}>
+                    <td>{r.name}</td>
+                    <td>{r.email}</td>
+                  </tr>
+                ))
+              }
+            </DataTable>
+          )
+        )
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+    it('renders nested rows', () => {
+      const nesteData = [
+        {
+          workloadId: 'default:deployment/myworkload',
+          containers: [
+            { name: 'nginx', behind: '4' },
+            { name: 'redis', behind: '1' },
+            { name: 'envoy', behind: '2' },
+          ],
+        },
+        {
+          workloadId: 'default:deployment/helloworld',
+          containers: [{ name: 'helloworld', behind: '2' }],
+        },
+      ];
+
+      const tree = renderer
+        .create(
+          withTheme(
+            <DataTable
+              data={nesteData}
+              sortBy="workloadId"
+              sortOrder="asc"
+              columns={[
+                { value: 'workloadId', label: 'Workload' },
+                { value: 'containers', label: 'Containers' },
+                { value: 'behind', label: 'Behind' },
+              ]}
+            >
+              {rows =>
+                map(rows, r => (
+                  <tbody key={r.workloadId}>
+                    {map(r.containers, (c, i) => (
+                      <tr key={c.name}>
+                        {i === 0 && <td rowSpan={r.containers.length}>{r.workloadId}</td>}
+                        <td>{c.name}</td>
+                        <td>{c.behind}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                ))
+              }
+            </DataTable>
+          )
+        )
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+  });
+  it('sorts on click', () => {
+    const table = mount(
+      withTheme(
+        <DataTable
+          data={data}
+          sortBy="email"
+          sortOrder="asc"
+          columns={[{ value: 'name', label: 'Name' }, { value: 'email', label: 'Email' }]}
+        >
+          {rows =>
+            map(rows, r => (
+              <tr key={r.email}>
+                <td>{r.name}</td>
+                <td>{r.email}</td>
+              </tr>
+            ))
+          }
+        </DataTable>
+      )
+    );
+
+    const $nameHeader = table.find('thead td').at(0);
+    const $emailHeader = table.find('thead td').at(1);
+    $nameHeader.simulate('click');
+    // Albert should be first, since we are sorting by name now.
+    expect(getFirstRowName(table)).toEqual('Albert');
+    // Back to email
+    $emailHeader.simulate('click');
+    expect(getFirstRowName(table)).toEqual('Bob');
+    // Click again to reverse the order.
+    $emailHeader.simulate('click');
+    expect(getFirstRowName(table)).toEqual('Ty');
+  });
+  it('handles custom sorting logic', () => {
+    // Custom sort function to sort by length instead of alphabetized.
+    const sortByNameLength = row => row.name.length;
+
+    const table = mount(
+      withTheme(
+        <DataTable
+          data={data}
+          sortBy="name"
+          sortOrder="asc"
+          columns={[{ value: 'name', label: 'Name' }, { value: 'email', label: 'Email' }]}
+          sortOverrides={{ name: sortByNameLength }}
+        >
+          {rows =>
+            map(rows, r => (
+              <tr key={r.email}>
+                <td>{r.name}</td>
+                <td>{r.email}</td>
+              </tr>
+            ))
+          }
+        </DataTable>
+      )
+    );
+    // Ty has the shortest name, so they should be first
+    expect(getFirstRowName(table)).toEqual('Ty');
+  });
+});

--- a/src/components/DataTable/_Header.js
+++ b/src/components/DataTable/_Header.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const StyledHeader = component => styled(component)`
+  text-align: left;
+  cursor: ${props => (props.sortable ? 'pointer' : 'inherit')};
+  user-select: none;
+
+  &:hover {
+    color: ${props => (props.sortable ? props.theme.colors.turquoise : 'inherit')};
+  }
+`;
+
+class Header extends React.Component {
+  handleClick = ev => {
+    const { onClick, value, sortable } = this.props;
+
+    if (onClick && sortable) {
+      onClick(ev, value);
+    }
+  };
+
+  render() {
+    const { className, children, order } = this.props;
+
+    return (
+      <td onClick={this.handleClick} className={className}>
+        {children}{' '}
+        {order && <i className={order === 'asc' ? 'fa fa-caret-up' : 'fa fa-caret-down'} />}
+      </td>
+    );
+  }
+}
+
+// Only way to declare default props :(
+const Styled = StyledHeader(Header);
+
+Styled.defaultProps = {
+  sortable: true,
+};
+
+export default Styled;

--- a/src/components/DataTable/__snapshots__/DataTable.test.js.snap
+++ b/src/components/DataTable/__snapshots__/DataTable.test.js.snap
@@ -1,0 +1,390 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataTable snapshots renders nested rows 1`] = `
+.c1 {
+  text-align: left;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c1:hover {
+  color: #037aa9;
+}
+
+.c0 {
+  border-collapse: collapse;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.c0 td {
+  padding: 10px 8px;
+  vertical-align: top;
+  border-left: 1px solid rgba(223,223,234,0.4);
+}
+
+.c0 thead td {
+  border: 0;
+  font-weight: bold;
+}
+
+.c0 thead,
+.c0 tbody {
+  border-bottom: 1px solid rgba(223,223,234,0.4);
+  border-left: 3px solid transparent;
+}
+
+<table
+  className="c0"
+>
+  <thead>
+    <tr>
+      <td
+        className="c1"
+        onClick={[Function]}
+      >
+        Workload
+         
+        <i
+          className="fa fa-caret-up"
+        />
+      </td>
+      <td
+        className="c1"
+        onClick={[Function]}
+      >
+        Containers
+         
+      </td>
+      <td
+        className="c1"
+        onClick={[Function]}
+      >
+        Behind
+         
+      </td>
+    </tr>
+  </thead>
+  <tbody>
+    <tbody>
+      <tr>
+        <td
+          rowSpan={1}
+        >
+          default:deployment/helloworld
+        </td>
+        <td>
+          helloworld
+        </td>
+        <td>
+          2
+        </td>
+      </tr>
+    </tbody>
+    <tbody>
+      <tr>
+        <td
+          rowSpan={3}
+        >
+          default:deployment/myworkload
+        </td>
+        <td>
+          nginx
+        </td>
+        <td>
+          4
+        </td>
+      </tr>
+      <tr>
+        <td>
+          redis
+        </td>
+        <td>
+          1
+        </td>
+      </tr>
+      <tr>
+        <td>
+          envoy
+        </td>
+        <td>
+          2
+        </td>
+      </tr>
+    </tbody>
+  </tbody>
+</table>
+`;
+
+exports[`DataTable snapshots renders rows 1`] = `
+.c1 {
+  text-align: left;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c1:hover {
+  color: #037aa9;
+}
+
+.c0 {
+  border-collapse: collapse;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.c0 td {
+  padding: 10px 8px;
+  vertical-align: top;
+  border-left: 1px solid rgba(223,223,234,0.4);
+}
+
+.c0 thead td {
+  border: 0;
+  font-weight: bold;
+}
+
+.c0 thead,
+.c0 tbody {
+  border-bottom: 1px solid rgba(223,223,234,0.4);
+  border-left: 3px solid transparent;
+}
+
+<table
+  className="c0"
+>
+  <thead>
+    <tr>
+      <td
+        className="c1"
+        onClick={[Function]}
+      >
+        Name
+         
+        <i
+          className="fa fa-caret-up"
+        />
+      </td>
+      <td
+        className="c1"
+        onClick={[Function]}
+      >
+        Email
+         
+      </td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        Albert
+      </td>
+      <td>
+        b@weave.works
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Bob
+      </td>
+      <td>
+        a@weave.works
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Ty
+      </td>
+      <td>
+        c@weave.works
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`DataTable snapshots sorts fields by a give order 1`] = `
+.c1 {
+  text-align: left;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c1:hover {
+  color: #037aa9;
+}
+
+.c0 {
+  border-collapse: collapse;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.c0 td {
+  padding: 10px 8px;
+  vertical-align: top;
+  border-left: 1px solid rgba(223,223,234,0.4);
+}
+
+.c0 thead td {
+  border: 0;
+  font-weight: bold;
+}
+
+.c0 thead,
+.c0 tbody {
+  border-bottom: 1px solid rgba(223,223,234,0.4);
+  border-left: 3px solid transparent;
+}
+
+<table
+  className="c0"
+>
+  <thead>
+    <tr>
+      <td
+        className="c1"
+        onClick={[Function]}
+      >
+        Name
+         
+      </td>
+      <td
+        className="c1"
+        onClick={[Function]}
+      >
+        Email
+         
+        <i
+          className="fa fa-caret-down"
+        />
+      </td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        Ty
+      </td>
+      <td>
+        c@weave.works
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Albert
+      </td>
+      <td>
+        b@weave.works
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Bob
+      </td>
+      <td>
+        a@weave.works
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`DataTable snapshots sorts rows by a field 1`] = `
+.c1 {
+  text-align: left;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c1:hover {
+  color: #037aa9;
+}
+
+.c0 {
+  border-collapse: collapse;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.c0 td {
+  padding: 10px 8px;
+  vertical-align: top;
+  border-left: 1px solid rgba(223,223,234,0.4);
+}
+
+.c0 thead td {
+  border: 0;
+  font-weight: bold;
+}
+
+.c0 thead,
+.c0 tbody {
+  border-bottom: 1px solid rgba(223,223,234,0.4);
+  border-left: 3px solid transparent;
+}
+
+<table
+  className="c0"
+>
+  <thead>
+    <tr>
+      <td
+        className="c1"
+        onClick={[Function]}
+      >
+        Name
+         
+      </td>
+      <td
+        className="c1"
+        onClick={[Function]}
+      >
+        Email
+         
+        <i
+          className="fa fa-caret-up"
+        />
+      </td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        Bob
+      </td>
+      <td>
+        a@weave.works
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Albert
+      </td>
+      <td>
+        b@weave.works
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Ty
+      </td>
+      <td>
+        c@weave.works
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;

--- a/src/components/DataTable/example.js
+++ b/src/components/DataTable/example.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import { map, max } from 'lodash';
+
+import { Example } from '../../utils/example';
+
+import DataTable from '.';
+
+const data = [
+  {
+    name: 'Bob',
+    email: 'a@weave.works',
+  },
+  {
+    name: 'Albert',
+    // Notice the emails are inverted to test sorting by this field
+    email: 'b@weave.works',
+  },
+];
+
+const nesteData = [
+  {
+    workloadId: 'default:deployment/myworkload',
+    containers: [
+      { name: 'nginx', behind: '4' },
+      { name: 'redis', behind: '1' },
+      { name: 'envoy', behind: '2' },
+    ],
+  },
+  {
+    workloadId: 'default:deployment/helloworld',
+    containers: [{ name: 'helloworld', behind: '2' }],
+  },
+];
+
+export default function DataTableExample() {
+  return (
+    <div>
+      <Example>
+        <h3>Default Table</h3>
+        <DataTable
+          data={data}
+          columns={[{ value: 'name', label: 'Name' }, { value: 'email', label: 'Email' }]}
+        >
+          {rows =>
+            map(rows, r => (
+              <tr key={r.email}>
+                <td>{r.name}</td>
+                <td>{r.email}</td>
+              </tr>
+            ))
+          }
+        </DataTable>
+      </Example>
+      <Example>
+        <h3>Nested Table</h3>
+        <DataTable
+          nested
+          data={nesteData}
+          sortBy="workloadId"
+          sortOrder="asc"
+          columns={[
+            { value: 'workloadId', label: 'Workload' },
+            { value: 'containers', label: 'Containers' },
+            { value: 'behind', label: 'Behind' },
+          ]}
+          sortOverrides={{ behind: row => max(map(row.containers, c => c.behind)) }}
+        >
+          {rows =>
+            map(rows, r => (
+              <tbody key={r.workloadId}>
+                {map(r.containers, (c, i) => (
+                  <tr key={c.name}>
+                    {i === 0 && <td rowSpan={r.containers.length}>{r.workloadId}</td>}
+                    <td>{c.name}</td>
+                    <td>{c.behind}</td>
+                  </tr>
+                ))}
+              </tbody>
+            ))
+          }
+        </DataTable>
+      </Example>
+    </div>
+  );
+}

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -1,0 +1,1 @@
+export default from './DataTable';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -27,3 +27,5 @@ export TimeTravel from './TimeTravel';
 export Dropdown from './Dropdown';
 
 export PrometheusGraph from './PrometheusGraph';
+
+export DataTable from './DataTable';

--- a/src/utils/compose.js
+++ b/src/utils/compose.js
@@ -1,0 +1,6 @@
+export function copyPropTypes(source, target) {
+  target.propTypes = { ...source.propTypes };
+  target.defaultProps = { ...source.defaultProps };
+
+  return target;
+}


### PR DESCRIPTION
Fixes #191 

Adds a sortable table component that can be used to show large data sets. Mimics the current behavior of the tables found in Weave Cloud.

Video: https://drive.google.com/file/d/1S-SD02ejNBObz9iwIg3Dgv4p6JEgE5mj/view

Key info:
* This component uses a [render-prop](https://reactjs.org/docs/render-props.html#using-props-other-than-render) pattern to encapsulate the sorting logic and pass down the sorted data to child components. The `children` argument that gets passed in should be a function.
* Custom sorting logic can be applied via the `sortOverrides` prop. The example and unit tests have reference implementations