### PR TITLE
Submit timestamp value only on enter or blur

### DIFF
--- a/src/components/TimeTravel/_TimestampInput.js
+++ b/src/components/TimeTravel/_TimestampInput.js
@@ -32,6 +32,8 @@ class TimestampInput extends React.PureComponent {
     };
 
     this.handleChange = this.handleChange.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.submit = this.submit.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -44,7 +46,16 @@ class TimestampInput extends React.PureComponent {
   handleChange(ev) {
     const timestamp = ev.target.value;
     this.setState({ timestamp });
+  }
 
+  handleKeyDown(ev) {
+    if (ev.keyCode === 13) {
+      this.submit();
+    }
+  }
+
+  submit() {
+    const timestamp = this.state.timestamp;
     if (moment(timestamp).isValid()) {
       this.props.onChangeTimestamp(timestamp);
     }
@@ -56,6 +67,8 @@ class TimestampInput extends React.PureComponent {
         <TimestampInputContainer
           value={this.state.timestamp}
           onChange={this.handleChange}
+          onBlur={this.submit}
+          onKeyDown={this.handleKeyDown}
           disabled={this.props.disabled}
         />{' '}
         UTC


### PR DESCRIPTION
Previously, when editing the timestamp value, the input field value was
replaced as soon as a loosely parsable date was found. This made editing
the timestamp cumbersome.

With this PR, the date will only be checked for validity and
subsequently sent to its parent only if Enter is pressed or the input loses
focus.