### PR TITLE
Update Google brand colors

### DIFF
--- a/src/theme/weave.js
+++ b/src/theme/weave.js
@@ -114,8 +114,8 @@ const colors = {
   // Third-party specific colors - not to be used in the theme!
   thirdParty: {
     // Google single-click login
-    wellRead: '#ad3131',
-    punch: '#dd4b39',
+    cornflowerBlue: '#4285f4',
+    azure: '#3769bb',
   },
 };
 


### PR DESCRIPTION
Update colors in Weave theme from red to blue, according to Google's
[brand guidelines](https://developers.google.com/identity/sign-in/web/build-button).