### PR TITLE
Reduce docs bundle size via uglify and NODE_ENV env variable

### DIFF
--- a/docs/js/Root.js
+++ b/docs/js/Root.js
@@ -21,7 +21,7 @@ const exampleCtx = require.context(
 const docCtx = require.context(
   '!!react-docs!../../src/components',
   true,
-  /^((?!test|index|example).)*$/
+  /^((?!test|index|example|_).)*$/
 );
 const styleGuideCtx = require.context('../../styleguide', true, /\.js$/);
 

--- a/docs/js/routes.js
+++ b/docs/js/routes.js
@@ -12,7 +12,7 @@ function buildExampleComponent(el, doc, example, sub) {
   return function ExampleWrapper() {
     return (
       <Example
-        name={el.displayName || el.name}
+        name={doc.name || el.name}
         element={el}
         example={example}
         doc={doc}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "postversion": "export TAG=$(jq -r '.version' package.json); git add package.json && git commit -m \"v${TAG}\" && git tag \"v${TAG}\" && git push origin --follow-tags",
     "prepublishOnly": "yarn ci && yarn build",
     "postpublish": "yarn docs:publish",
-    "docs:build": "RELEASE=true rm -rf dist && webpack --config webpack.config.js",
+    "docs:build": "export NODE_ENV=production; export RELEASE=true; rm -rf dist && webpack --config webpack.config.js",
     "docs:copy-images": "cp -R src/images dist",
     "docs:s3": "aws --profile default-mfa s3 sync ./dist/ s3://weaveworks-ui-components --acl public-read",
     "docs:publish": "yarn docs:build && yarn docs:copy-images && yarn docs:s3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,6 +74,18 @@ if (process.env.RELEASE) {
       template: 'docs/index.html',
       filename: 'index.html',
     }),
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify('production'),
+      },
+    }),
+    new webpack.optimize.UglifyJsPlugin({
+      sourceMap: false,
+      comments: false,
+      compress: {
+        warnings: false,
+      },
+    }),
   ];
 } else {
   // Normal sass loader. This complains if it runs in the RELEASE job, so only apply it if RELEASE
@@ -86,7 +98,7 @@ if (process.env.RELEASE) {
 
 module.exports = {
   externals,
-  devtool: 'eval-source-map',
+  devtool: process.env.NODE_ENV !== 'production' ? 'eval-source-map' : null,
   resolveLoader: {
     alias: {
       'react-docs': path.join(__dirname, 'src/loaders/react-docs.js'),


### PR DESCRIPTION
Fixes #10 

Adds some uglification, adds in the correct env variable, and skips evaluation of `_` prefixed files when evaluating documentation.

Bundle size goes from ~17MB to 2.6MB.

Before:
```
Hash: f03c02e51c363b2712c4
Version: webpack 1.13.3
Time: 16719ms
                                 Asset       Size  Chunks             Chunk Names
               fontawesome-webfont.eot     166 kB          [emitted]  
af7ae505a9eed503f8b8e6982036873e.woff2    77.2 kB          [emitted]  
 fee66e712a8a08eef5805a46892932ad.woff      98 kB          [emitted]  
               fontawesome-webfont.ttf     166 kB          [emitted]  
               fontawesome-webfont.svg     444 kB          [emitted]  
 a7942249ca925ef356c0f2b1dab17ef3.woff      29 kB          [emitted]  
                           favicon.ico    7.16 kB          [emitted]  
                               docs.js    16.9 MB       0  [emitted]  docs
                            index.html  201 bytes          [emitted]  
```

After: 
```
Hash: f68ad273d6a3521c5ed2
Version: webpack 1.13.3
Time: 21737ms
                                 Asset       Size  Chunks             Chunk Names
 a7942249ca925ef356c0f2b1dab17ef3.woff      29 kB          [emitted]  
               fontawesome-webfont.eot     166 kB          [emitted]  
af7ae505a9eed503f8b8e6982036873e.woff2    77.2 kB          [emitted]  
 fee66e712a8a08eef5805a46892932ad.woff      98 kB          [emitted]  
               fontawesome-webfont.ttf     166 kB          [emitted]  
               fontawesome-webfont.svg     444 kB          [emitted]  
                           favicon.ico    7.16 kB          [emitted]  
                               docs.js    2.66 MB       0  [emitted]  docs
                              docs.css    13.6 kB       0  [emitted]  docs
                            index.html  296 bytes          [emitted]  
```

2.6MB is still too high, but a ~650% improvement is good enough for now.