### PR TITLE
Enforce theme font families

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -21,6 +21,11 @@
     }],
     "sh-waqar/declaration-use-variable": [[
       "border-radius",
+      "border-top-left-radius",
+      "border-top-right-radius",
+      "border-bottom-left-radius",
+      "border-bottom-right-radius",
+      "font-family",
       "font-size",
       "z-index"
     ]],

--- a/docs/css/demo.scss
+++ b/docs/css/demo.scss
@@ -10,7 +10,8 @@
 
 body {
   background-color: #f5f4f4;
-  font-family: 'proxima-nova', sans-serif;
+  /* Taken from theme/fonts */
+  font-family: 'proxima-nova', Helvetica, Arial, sans-serif;
   text-align: left;
 }
 

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -23,7 +23,9 @@ import '../img/favicon.ico';
   optgroup,
   select,
   textarea {
+    /* stylelint-disable sh-waqar/declaration-use-variable */
     font-family: inherit;
+    /* stylelint-enable sh-waqar/declaration-use-variable */
   }
 `)();
 

--- a/src/components/PrometheusGraph/_HoverInfo.js
+++ b/src/components/PrometheusGraph/_HoverInfo.js
@@ -38,7 +38,7 @@ const TooltipRowName = styled.span`
 `;
 
 const TooltipRowValue = styled.span`
-  font-family: 'Roboto', sans-serif;
+  font-family: ${props => props.theme.fontFamilies.monospace};
   margin-left: 20px;
   white-space: nowrap;
 `;

--- a/src/components/PrometheusGraph/_Tooltip.js
+++ b/src/components/PrometheusGraph/_Tooltip.js
@@ -24,7 +24,7 @@ const TooltipContainer = styled.div.attrs({
 `;
 
 const Timestamp = styled.div`
-  font-family: 'Roboto', sans-serif;
+  color: ${props => props.theme.colors.doveGray};
   font-size: ${props => props.theme.fontSizes.small};
   margin-bottom: 8px;
 `;

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { lookupValue } from '../../utils/theme';
 
 const StyledText = styled.span`
-  font-family: ${props => props.theme.fontFamily};
+  font-family: ${props => props.theme.fontFamilies.regular};
   color: ${props => props.theme.textColor};
   font-size: ${props => lookupValue(props, props.theme.fontSizes, props.theme.fontSizes.normal)};
   font-weight: ${props => (props.bold ? '600' : '400')};
@@ -14,8 +14,7 @@ const StyledText = styled.span`
 `;
 
 /**
- * Text! supports all the sizes from _theme.fontSizes_.
- * The font is proxima-nova.
+ * Text supports all the sizes from _theme.fontSizes_.
  * ```javascript
  * import { Text } from 'weaveworks-ui-components';
  *

--- a/src/components/Text/__snapshots__/Text.test.js.snap
+++ b/src/components/Text/__snapshots__/Text.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Text /> renderes bold 1`] = `
 .c0 {
-  font-family: 'proxima-nova',sans-serif,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   color: #1a1a1a;
   font-size: 16px;
   font-weight: 600;
@@ -17,7 +17,7 @@ exports[`<Text /> renderes bold 1`] = `
 
 exports[`<Text /> renders default 1`] = `
 .c0 {
-  font-family: 'proxima-nova',sans-serif,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   color: #1a1a1a;
   font-size: 16px;
   font-weight: 400;
@@ -32,7 +32,7 @@ exports[`<Text /> renders default 1`] = `
 
 exports[`<Text /> renders italic 1`] = `
 .c0 {
-  font-family: 'proxima-nova',sans-serif,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   color: #1a1a1a;
   font-size: 16px;
   font-weight: 400;
@@ -47,7 +47,7 @@ exports[`<Text /> renders italic 1`] = `
 
 exports[`<Text /> renders large 1`] = `
 .c0 {
-  font-family: 'proxima-nova',sans-serif,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   color: #1a1a1a;
   font-size: 22px;
   font-weight: 400;

--- a/src/components/TimeTravel/_RangeSelector.js
+++ b/src/components/TimeTravel/_RangeSelector.js
@@ -13,8 +13,6 @@ const RangeSelectorWrapper = styled.div`
 const SelectedRangeWrapper = styled.div`
   background-color: transparent;
   cursor: pointer;
-  font-family: 'Roboto', sans-serif;
-  font-size: ${props => props.theme.fontSizes.normal};
   padding: 3px 8px;
   display: flex;
   justify-content: space-between;

--- a/src/components/TimeTravel/_TimestampInput.js
+++ b/src/components/TimeTravel/_TimestampInput.js
@@ -14,11 +14,11 @@ const TimestampInputWrapper = styled.div`
 
 const TimestampInputContainer = styled.input`
   font-size: ${props => props.theme.fontSizes.normal};
+  font-family: ${props => props.theme.fontFamilies.monospace};
   background-color: transparent;
-  font-family: 'Roboto', sans-serif;
   margin-right: 3px;
-  text-align: center;
-  width: 165px;
+  text-align: left;
+  width: 195px;
   border: 0;
   outline: 0;
 `;

--- a/src/theme/fonts.js
+++ b/src/theme/fonts.js
@@ -1,5 +1,10 @@
 import { kebabCase, forEach } from 'lodash';
 
+export const fontFamilies = {
+  regular: "'proxima-nova', Helvetica, Arial, sans-serif",
+  monospace: "'Roboto Mono', monospace",
+};
+
 export const fontSizes = {
   huge: '48px',
   extraLarge: '32px',
@@ -9,16 +14,17 @@ export const fontSizes = {
   tiny: '12px',
 };
 
-export const fontFamily =
-  "'proxima-nova', sans-serif, 'Helvetica Neue', Helvetica, Arial, sans-serif";
+// Collects all theme font vars as SCSS vars.
+export function themeFontsAsScss() {
+  const themeFonts = [];
 
-// Collects all theme font sizes as SCSS vars.
-export function themeFontSizesAsScss() {
-  const themeFontSizes = [];
-
-  forEach(fontSizes, (value, name) => {
-    themeFontSizes.push(`$font-size-${kebabCase(name)}: ${value}`);
+  forEach(fontFamilies, (value, name) => {
+    themeFonts.push(`$font-family-${kebabCase(name)}: ${value}`);
   });
 
-  return themeFontSizes;
+  forEach(fontSizes, (value, name) => {
+    themeFonts.push(`$font-size-${kebabCase(name)}: ${value}`);
+  });
+
+  return themeFonts;
 }

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,5 +1,5 @@
 import { colors, themeColorsAsScss } from './colors';
-import { fontSizes, fontFamily, themeFontSizesAsScss } from './fonts';
+import { fontSizes, fontFamilies, themeFontsAsScss } from './fonts';
 import { borderRadius, themeBorderRadiiAsScss } from './borders';
 import { layers, themeLayersAsScss } from './layers';
 import { overlayIconSize, textColor, themeMiscVarsAsScss } from './misc';
@@ -10,7 +10,7 @@ export function themeVarsAsScss() {
   const themeVariables = []
     .concat(themeColorsAsScss())
     .concat(themeLayersAsScss())
-    .concat(themeFontSizesAsScss())
+    .concat(themeFontsAsScss())
     .concat(themeBorderRadiiAsScss())
     .concat(themeMiscVarsAsScss());
   return `${themeVariables.join('; ')};`;
@@ -30,7 +30,7 @@ const theme = {
   colors,
 
   // Fonts
-  fontFamily,
+  fontFamilies,
   fontSizes,
 
   // z-index layers

--- a/styleguide/Fonts.js
+++ b/styleguide/Fonts.js
@@ -13,6 +13,12 @@ const FontRow = styled.div`
   margin-bottom: 5px;
 `;
 
+const FontFamily = styled.div`
+  font-family: ${props => props.family};
+  font-size: ${props => props.theme.fontSizes.normal};
+  opacity: 0.5;
+`;
+
 const curly = start => (start ? '{' : '}');
 
 class Fonts extends React.Component {
@@ -32,13 +38,36 @@ class Fonts extends React.Component {
             `;
           </pre>
         </Row>
-        {map(theme.fontSizes, (value, name) => (
-          <FontRow key={name}>
-            <Text {...{[name]: true}} style={{ opacity: 0.5 }}>
-              theme.fontSizes.{name} ({value})
-            </Text>
-          </FontRow>
-        ))}
+        <Row>
+          {map(theme.fontSizes, (value, name) => (
+            <FontRow key={name}>
+              <Text {...{[name]: true}} style={{ opacity: 0.5 }}>
+                theme.fontSizes.{name} ({value})
+              </Text>
+            </FontRow>
+          ))}
+        </Row>
+
+        <Row>
+          <Text extraLarge>Font families</Text>
+        </Row>
+        <Row>
+          <pre>
+            const MyButton = styled.button`
+            <br />
+            &nbsp; font-family: ${curly(true)}props =&gt;
+            props.theme.fontFamilies.monospace{curly(false)};
+            <br />
+            `;
+          </pre>
+        </Row>
+        <Row>
+          {map(theme.fontFamilies, (value, name) => (
+            <FontFamily key={name} family={value}>
+              theme.fontFamilies.{name}
+            </FontFamily>
+          ))}
+        </Row>
       </div>
     );
   }


### PR DESCRIPTION
First step in resolving #212.
Resolves #216.

**Note:** Some _Roboto_ text in `PrometheusGraph` tooltips, as well as `TimeTravel` timestamp input box was changed to _monospace_, resulting in different looks, most notably:

##### Before
![image](https://user-images.githubusercontent.com/1216874/40125365-0ab14874-592b-11e8-9d1b-a9eaa0af943a.png)

##### After
![image](https://user-images.githubusercontent.com/1216874/40125321-eb8779be-592a-11e8-877d-cf51956b2795.png)
