### PR TITLE
PrometheusGraph legend items selection hook

### DIFF
--- a/src/components/PrometheusGraph/PrometheusGraph.js
+++ b/src/components/PrometheusGraph/PrometheusGraph.js
@@ -20,6 +20,7 @@ import {
   every,
   get,
   reverse,
+  indexOf,
 } from 'lodash';
 import { scaleLinear, scaleQuantize } from 'd3-scale';
 import { format, formatPrefix, precisionPrefix, precisionFixed } from 'd3-format';
@@ -249,7 +250,21 @@ class PrometheusGraph extends React.PureComponent {
     const getSeriesColor = getColorTheme(props);
     const getSeriesName = (series, forLegend) =>
       props.getSeriesName(series, props.multiSeries, forLegend);
-    const getSeriesKey = (series, index) => `${getSeriesName(series)}:${index}`;
+
+    // The key generating function will make series key equal the series name,
+    // unless this is not the first series with this name, in which case the
+    // index of the series within the legend is attached to the key.
+    const multiSeriesByName = props.multiSeries.map(getSeriesName);
+    const getSeriesKey = (series, index) => {
+      const seriesName = getSeriesName(series);
+      const firstIndex = indexOf(multiSeriesByName, seriesName);
+
+      let seriesKey = seriesName;
+      if (firstIndex !== index) {
+        seriesKey = `${seriesKey}____${index}`;
+      }
+      return seriesKey;
+    };
 
     // Build a dictionary that references original multi series by keys,
     // and a sorted list of those keys by which we can later iterate.

--- a/src/components/PrometheusGraph/_Chart.js
+++ b/src/components/PrometheusGraph/_Chart.js
@@ -122,27 +122,20 @@ class Chart extends React.PureComponent {
   }
 
   isFadedSeries(series) {
-    const {
-      hoveredLegendSeriesKey,
-      selectedLegendMultiSeriesKeys,
-    } = this.props;
+    const { hoveredLegendKey, selectedLegendKeys } = this.props;
     // Show series as faded if no series is selected and some other series is hovered.
     return (
-      selectedLegendMultiSeriesKeys.length === 0 &&
-      hoveredLegendSeriesKey &&
-      hoveredLegendSeriesKey !== series.key
+      selectedLegendKeys.length === 0 &&
+      hoveredLegendKey &&
+      hoveredLegendKey !== series.key
     );
   }
 
   isFocusedSeries(series) {
-    const {
-      hoveredLegendSeriesKey,
-      selectedLegendMultiSeriesKeys,
-    } = this.props;
+    const { hoveredLegendKey, selectedLegendKeys } = this.props;
     // Show series as focused if it's selected or hovered.
     return (
-      hoveredLegendSeriesKey === series.key ||
-      selectedLegendMultiSeriesKeys.includes(series.key)
+      hoveredLegendKey === series.key || selectedLegendKeys.includes(series.key)
     );
   }
 
@@ -197,8 +190,8 @@ Chart.propTypes = {
   timeScale: PropTypes.func.isRequired,
   valueScale: PropTypes.func.isRequired,
   timestampQuantizer: PropTypes.func.isRequired,
-  selectedLegendMultiSeriesKeys: PropTypes.array.isRequired,
-  hoveredLegendSeriesKey: PropTypes.string,
+  selectedLegendKeys: PropTypes.array.isRequired,
+  hoveredLegendKey: PropTypes.string,
   onHoverUpdate: PropTypes.func.isRequired,
   onChartResize: PropTypes.func.isRequired,
 };

--- a/src/components/PrometheusGraph/_Legend.js
+++ b/src/components/PrometheusGraph/_Legend.js
@@ -71,10 +71,15 @@ class Legend extends React.PureComponent {
 
     this.state = {
       shown: props.shown,
+      selectedKeys: props.selectedKeys,
       hoveredKey: null,
-      selectedKeys: [],
-      multiSeries: [],
     };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.selectedKeys !== nextProps.selectedKeys) {
+      this.setState({ selectedKeys: nextProps.selectedKeys });
+    }
   }
 
   handleLegendItemClick = (ev, series) => {
@@ -95,17 +100,17 @@ class Legend extends React.PureComponent {
     }
 
     this.setState({ selectedKeys });
-    this.props.onSelectedMultiSeriesChange(selectedKeys);
+    this.props.onSelectedKeysChange(selectedKeys);
   };
 
   handleLegendItemMouseEnter = series => {
     this.setState({ hoveredKey: series.key });
-    this.props.onHoveredSeriesChange(series.key);
+    this.props.onHoveredKeyChange(series.key);
   };
 
   handleLegendItemMouseLeave = () => {
     this.setState({ hoveredKey: null });
-    this.props.onHoveredSeriesChange(null);
+    this.props.onHoveredKeyChange(null);
   };
 
   handleLegendToggle = () => {
@@ -148,8 +153,9 @@ class Legend extends React.PureComponent {
 
 Legend.propTypes = {
   multiSeries: PropTypes.array.isRequired,
-  onSelectedMultiSeriesChange: PropTypes.func.isRequired,
-  onHoveredSeriesChange: PropTypes.func.isRequired,
+  selectedKeys: PropTypes.array.isRequired,
+  onSelectedKeysChange: PropTypes.func.isRequired,
+  onHoveredKeyChange: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired,
   collapsable: PropTypes.bool.isRequired,
   shown: PropTypes.bool.isRequired,

--- a/src/components/PrometheusGraph/example.js
+++ b/src/components/PrometheusGraph/example.js
@@ -1,10 +1,17 @@
 import React from 'react';
 import faker from 'faker';
 import moment from 'moment';
+import styled from 'styled-components';
 import { compact, range, times } from 'lodash';
 
 import PrometheusGraph from '.';
 import { Example, Info } from '../../utils/example';
+
+const InlineBlock = styled.div`
+  display: inline-block;
+  margin-right: 5%;
+  width: 45%;
+`;
 
 function generateRandomMultiSeries(
   { startTime, endTime, stepDuration },
@@ -13,6 +20,20 @@ function generateRandomMultiSeries(
 ) {
   return times(count, () => ({
     metric: { [key]: faker.lorem.slug() },
+    values: range(startTime, endTime + 1e-6, stepDuration).map(time => [
+      time,
+      faker.random.number({ min: 10, max: 20 }),
+    ]),
+  }));
+}
+
+function generateCorrelatedMultiSeries(
+  { startTime, endTime, stepDuration },
+  key,
+  count
+) {
+  return times(count, index => ({
+    metric: { [key]: ['aaa', 'bbb', 'bbb', 'ccc', 'ddd'][index] },
     values: range(startTime, endTime + 1e-6, stepDuration).map(time => [
       time,
       faker.random.number({ min: 10, max: 20 }),
@@ -37,6 +58,7 @@ export default class PrometheusGraphExample extends React.Component {
     super();
 
     this.state = {
+      selectedCorrelatedKeys: [],
       startTime: moment('2018-02-05T11:24:14Z').unix(),
       endTime: moment('2018-02-05T11:54:14Z').unix(),
       stepDuration: 9,
@@ -53,6 +75,16 @@ export default class PrometheusGraphExample extends React.Component {
       'namespace',
       4
     );
+    this.state.multiSeriesCorrelatedA = generateCorrelatedMultiSeries(
+      this.state,
+      'namespace',
+      5
+    );
+    this.state.multiSeriesCorrelatedB = generateCorrelatedMultiSeries(
+      this.state,
+      'namespace',
+      5
+    );
     this.state.deployments = generateDeployments(this.state, 6);
   }
 
@@ -68,6 +100,10 @@ export default class PrometheusGraphExample extends React.Component {
   componentWillUnmount() {
     clearInterval(this.timer);
   }
+
+  changeLegendSelection = (selectedCorrelatedKeys) => {
+    this.setState({ selectedCorrelatedKeys });
+  };
 
   render() {
     return (
@@ -101,6 +137,31 @@ export default class PrometheusGraphExample extends React.Component {
             endTimeSec={this.state.endTime}
             deployments={this.state.deployments}
           />
+          <Info>Correlated graphs</Info>
+          <InlineBlock>
+            <PrometheusGraph
+              showStacked
+              selectedLegendKeys={this.state.selectedCorrelatedKeys}
+              onChangeLegendSelection={this.changeLegendSelection}
+              multiSeries={this.state.multiSeriesCorrelatedA}
+              stepDurationSec={this.state.stepDuration}
+              startTimeSec={this.state.startTime}
+              endTimeSec={this.state.endTime}
+              deployments={this.state.deployments}
+            />
+          </InlineBlock>
+          <InlineBlock>
+            <PrometheusGraph
+              showStacked
+              selectedLegendKeys={this.state.selectedCorrelatedKeys}
+              onChangeLegendSelection={this.changeLegendSelection}
+              multiSeries={this.state.multiSeriesCorrelatedB}
+              stepDurationSec={this.state.stepDuration}
+              startTimeSec={this.state.startTime}
+              endTimeSec={this.state.endTime}
+              deployments={this.state.deployments}
+            />
+          </InlineBlock>
           <Info>Error with no data</Info>
           <PrometheusGraph
             showStacked


### PR DESCRIPTION
Resolves #198.

##### Changes

* Modified the way series keys are chosen so that they will differ from series names only if they repeat multiple times in the legend. So, when we know they don't repeat, we can assume `seriesKey === seriesName`.
* Added `onChangeLegendSelection` to `PrometheusGraph` to notify the outside world of legend selection changes.
* Added `selectedLegendKeys` prop to `PrometheusGraph` that overrides the local state whenever it's changed (this pattern has already been repeated in a lot of our React components that communicate their internal state with the outside world and it seems to work fine).
* Added an example of two correlated graphs which demonstrates how we could have a _global_ legend state selection system.

![image](https://user-images.githubusercontent.com/1216874/40184563-db2a1830-59f0-11e8-835f-fbec7da6c10e.png)
