### PR TITLE
Add TabSelect component

### DIFF
--- a/docs/js/ComponentsPage.js
+++ b/docs/js/ComponentsPage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { values, flatMap, includes, reduce } from 'lodash';
+import { values, flatMap, includes, reduce, concat } from 'lodash';
 
 import { isActivePage } from './utils';
 
@@ -43,16 +43,18 @@ class ComponentsPage extends React.Component {
             text={module}
           />
         );
-        // Determine the link matches the top level dir. Else, creates an array of subModules.
-        if (isDefault && !result[dir]) {
-          result[dir] = { component: item };
-        } else if (!isDefault && result[dir]) {
-          if (!result[dir].subModules) {
-            result[dir].subModules = [item];
-          } else {
-            result[dir].subModules.push(item);
-          }
+
+        if (!result[dir]) {
+          // Haven't made the directory entry yet.
+          result[dir] = {};
         }
+
+        if (isDefault) {
+          result[dir].component = item;
+        } else {
+          result[dir].subModules = concat(result[dir].subModules || [], item);
+        }
+
         return result;
       },
       {}

--- a/src/components/TabSelect/Tab.js
+++ b/src/components/TabSelect/Tab.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+const Styled = component => styled(component)``;
+
+/**
+ * A tab component for use within a TabSelect component.
+ *  * See also:
+ * [TabSelect](/components/tabselect)
+ */
+
+class Tab extends React.PureComponent {
+  render() {
+    const { className, children } = this.props;
+    return <div className={className}>{children}</div>;
+  }
+}
+
+Tab.propTypes = {
+  /**
+   * The label of the tab. This will appear in the TabSelect navigation section
+   */
+  label: PropTypes.string.isRequired,
+  /**
+   * A unique identifier for this tab
+   */
+  name: PropTypes.string.isRequired,
+};
+
+export default Styled(Tab);

--- a/src/components/TabSelect/TabSelect.js
+++ b/src/components/TabSelect/TabSelect.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import styled from 'styled-components';
+import { pick, map, find, get } from 'lodash';
+import PropTypes from 'prop-types';
+
+import Tab from './Tab';
+import TabButton from './_TabButton';
+
+const TabButtons = styled.div``;
+
+const TabContent = styled.div`
+  padding: 20px;
+  background-color: ${props => props.theme.colors.white};
+
+  ${props => `
+    border-top-right-radius: ${props.theme.borderRadius.soft};
+    border-bottom-right-radius: ${props.theme.borderRadius.soft};
+    border-bottom-left-radius: ${props.theme.borderRadius.soft};
+    border: 1px solid ${props.theme.colors.athens};
+  `};
+`;
+
+const Styled = component => styled(component)``;
+
+class TabSelect extends React.PureComponent {
+  state = {
+    selectedTab:
+      // Use the first tab as the default if no selectedTab prop is specified.
+      this.props.selectedTab || get(this.props.children, '[0].props.name'),
+  };
+
+  componentWillReceiveProps(nextProps) {
+    // Always override user-selected tab with the default one from
+    // the prop input (so that URL param can take precedence).
+    if (nextProps.selectedTab !== this.props.selectedTab) {
+      this.setState({ selectedTab: nextProps.selectedTab });
+    }
+  }
+
+  isSelectedTab = ({ name }) => name === this.state.selectedTab;
+
+  handleTabClick = (ev, tabName) => {
+    this.setState({ selectedTab: tabName });
+
+    if (this.props.onChange) {
+      this.props.onChange(ev, tabName);
+    }
+  };
+
+  render() {
+    const { className, children } = this.props;
+    const tabs = React.Children.map(children, child =>
+      pick(child.props, ['label', 'name'])
+    );
+
+    const selected = find(children, c => this.isSelectedTab(c.props));
+
+    return (
+      <div className={className}>
+        <TabButtons>
+          {map(tabs, tab => (
+            <TabButton
+              key={tab.name}
+              name={tab.name}
+              selected={this.isSelectedTab(tab)}
+              onClick={this.handleTabClick}
+            >
+              {tab.label}
+            </TabButton>
+          ))}
+        </TabButtons>
+        <TabContent>{selected}</TabContent>
+      </div>
+    );
+  }
+}
+
+TabSelect.propTypes = {
+  /**
+   * The tab to show on first render.
+   * Supplying a new value to this prop will override the currently selected item
+   */
+  selectedTab: PropTypes.string,
+  /**
+   * Children of `TabSelect` must be a `Tab` component
+   */
+  children: (props, propName) => {
+    let error = null;
+    React.Children.forEach(props[propName], child => {
+      if (child.type !== Tab) {
+        error = new Error(
+          `Wrong component supplied to TabSelect. Expected a <Tab />, got a ${
+            child.type
+          }`
+        );
+      }
+    });
+    return error;
+  },
+};
+
+export default Styled(TabSelect);

--- a/src/components/TabSelect/TabSelect.test.js
+++ b/src/components/TabSelect/TabSelect.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import renderer from 'react-test-renderer';
+import 'jest-styled-components';
+import { withTheme } from '../../utils/theme';
+
+import TabSelect from './TabSelect';
+import Tab from './Tab';
+import TabButton from './_TabButton';
+
+describe('<Tab Select />', () => {
+  describe('snapshots', () => {
+    it('renders', () => {
+      const tree = renderer
+        .create(
+          withTheme(
+            <TabSelect>
+              <Tab label="A" name="a">
+                Tab A
+              </Tab>
+              <Tab label="B" name="b">
+                Tab B
+              </Tab>
+              <Tab label="C" name="c">
+                Tab C
+              </Tab>
+            </TabSelect>
+          )
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+    it('renders with a selectedTab', () => {
+      const tree = renderer
+        .create(
+          withTheme(
+            <TabSelect selectedTab="b">
+              <Tab label="A" name="a">
+                Tab A
+              </Tab>
+              <Tab label="B" name="b">
+                Tab B
+              </Tab>
+              <Tab label="C" name="c">
+                Tab C
+              </Tab>
+            </TabSelect>
+          )
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+  it('changes tabs on click', () => {
+    const tabs = mount(
+      withTheme(
+        <TabSelect>
+          <Tab label="A" name="a">
+            Tab A
+          </Tab>
+          <Tab label="B" name="b">
+            Tab B
+          </Tab>
+          <Tab label="C" name="c">
+            Tab C
+          </Tab>
+        </TabSelect>
+      )
+    );
+
+    tabs
+      .find(TabButton)
+      .at(1)
+      .simulate('click');
+    expect(tabs.find(Tab).text()).toEqual('Tab B');
+  });
+});

--- a/src/components/TabSelect/_TabButton.js
+++ b/src/components/TabSelect/_TabButton.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const TabName = styled.span``;
+
+const Styled = component => styled(component)`
+  cursor: pointer;
+  margin-bottom: -1px;
+  margin-right: 5px;
+  padding: 10px 20px;
+  font-size: ${props => props.theme.fontSizes.large};
+  outline: 0;
+
+  ${({ selected, theme }) => `
+    background-color: ${selected ? theme.colors.white : theme.colors.lightgray};
+    border-top-left-radius: ${theme.borderRadius.soft};
+    border-top-right-radius: ${theme.borderRadius.soft};
+    border: 1px solid ${theme.colors.athens};
+  `};
+
+  ${props => props.selected && 'border-bottom: 1px solid transparent;'};
+
+  ${TabName} {
+    color: ${props => props.theme.colors.primary.charcoal};
+    opacity: ${props => (props.selected ? 1 : 0.65)};
+  }
+`;
+
+class TabButton extends React.Component {
+  handeClick = ev => {
+    this.props.onClick(ev, this.props.name);
+  };
+
+  render() {
+    const { className, children } = this.props;
+    return (
+      <button onClick={this.handeClick} className={className}>
+        <TabName>{children}</TabName>
+      </button>
+    );
+  }
+}
+
+export default Styled(TabButton);

--- a/src/components/TabSelect/__snapshots__/TabSelect.test.js.snap
+++ b/src/components/TabSelect/__snapshots__/TabSelect.test.js.snap
@@ -1,0 +1,193 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Tab Select /> snapshots renders 1`] = `
+.c0 {
+  cursor: pointer;
+  margin-bottom: -1px;
+  margin-right: 5px;
+  padding: 10px 20px;
+  font-size: 22px;
+  outline: 0;
+  background-color: #fff;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border: 1px solid #e2e2ec;
+  border-bottom: 1px solid transparent;
+}
+
+.c0 .c1 {
+  color: #32324b;
+  opacity: 1;
+}
+
+.c2 {
+  cursor: pointer;
+  margin-bottom: -1px;
+  margin-right: 5px;
+  padding: 10px 20px;
+  font-size: 22px;
+  outline: 0;
+  background-color: #f8f8f8;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border: 1px solid #e2e2ec;
+}
+
+.c2 .c1 {
+  color: #32324b;
+  opacity: 0.65;
+}
+
+.c3 {
+  padding: 20px;
+  background-color: #fff;
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+  border: 1px solid #e2e2ec;
+}
+
+<div
+  className=""
+>
+  <div
+    className=""
+  >
+    <button
+      className="c0"
+      onClick={[Function]}
+    >
+      <span
+        className="c1 "
+      >
+        A
+      </span>
+    </button>
+    <button
+      className="c2"
+      onClick={[Function]}
+    >
+      <span
+        className="c1 "
+      >
+        B
+      </span>
+    </button>
+    <button
+      className="c2"
+      onClick={[Function]}
+    >
+      <span
+        className="c1 "
+      >
+        C
+      </span>
+    </button>
+  </div>
+  <div
+    className="c3"
+  >
+    <div
+      className=""
+    >
+      Tab A
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Tab Select /> snapshots renders with a selectedTab 1`] = `
+.c2 {
+  cursor: pointer;
+  margin-bottom: -1px;
+  margin-right: 5px;
+  padding: 10px 20px;
+  font-size: 22px;
+  outline: 0;
+  background-color: #fff;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border: 1px solid #e2e2ec;
+  border-bottom: 1px solid transparent;
+}
+
+.c2 .c1 {
+  color: #32324b;
+  opacity: 1;
+}
+
+.c0 {
+  cursor: pointer;
+  margin-bottom: -1px;
+  margin-right: 5px;
+  padding: 10px 20px;
+  font-size: 22px;
+  outline: 0;
+  background-color: #f8f8f8;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border: 1px solid #e2e2ec;
+}
+
+.c0 .c1 {
+  color: #32324b;
+  opacity: 0.65;
+}
+
+.c3 {
+  padding: 20px;
+  background-color: #fff;
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+  border: 1px solid #e2e2ec;
+}
+
+<div
+  className=""
+>
+  <div
+    className=""
+  >
+    <button
+      className="c0"
+      onClick={[Function]}
+    >
+      <span
+        className="c1 "
+      >
+        A
+      </span>
+    </button>
+    <button
+      className="c2"
+      onClick={[Function]}
+    >
+      <span
+        className="c1 "
+      >
+        B
+      </span>
+    </button>
+    <button
+      className="c0"
+      onClick={[Function]}
+    >
+      <span
+        className="c1 "
+      >
+        C
+      </span>
+    </button>
+  </div>
+  <div
+    className="c3"
+  >
+    <div
+      className=""
+    >
+      Tab B
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/TabSelect/example.js
+++ b/src/components/TabSelect/example.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { Example } from '../../utils/example';
+import TabSelect from './TabSelect';
+import Tab from './Tab';
+
+export default function TabSelectExample() {
+  return (
+    <Example>
+      <TabSelect>
+        <Tab label="A" name="a">
+          Tab A
+        </Tab>
+        <Tab label="B" name="b">
+          Tab B
+        </Tab>
+        <Tab label="C" name="c">
+          Tab C
+        </Tab>
+      </TabSelect>
+    </Example>
+  );
+}

--- a/src/components/TabSelect/index.js
+++ b/src/components/TabSelect/index.js
@@ -1,0 +1,4 @@
+export TabSelect from './TabSelect';
+export Tab from './Tab';
+
+export default from './TabSelect';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -31,3 +31,5 @@ export PrometheusGraph from './PrometheusGraph';
 export DataTable from './DataTable';
 
 export TimestampTag from './TimestampTag';
+
+export TabSelect, { Tab } from './TabSelect';


### PR DESCRIPTION
Closes #190 

Adds a TabSelect component, borrowing heavily from the current implementation in service-ui.

I am kind of ignoring my own advice about introspecting into `children`, but I looked at some similar third party components and it seems like it might be okay. At least the `propType` validation will throw an error if any type of unreadable component shows up as a child.

API looks like this:

```javascript
      <TabSelect>
        <Tab label="A" name="a">
          Tab A
        </Tab>
        <Tab label="B" name="b">
          Tab B
        </Tab>
        <Tab label="C" name="c">
          Tab C
        </Tab>
      </TabSelect>
```

Renders:
![screen shot 2018-05-17 at 3 44 26 pm](https://user-images.githubusercontent.com/2802257/40207408-3bbd12ea-59e9-11e8-9ed3-51035e84ad84.png)
