### PR TITLE
Support primitive deployment annotations in TimeTravel timeline

### DIFF
--- a/src/components/TimeTravel/TimeTravel.js
+++ b/src/components/TimeTravel/TimeTravel.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { clamp, find, debounce, noop } from 'lodash';
 
 import { formattedTimestamp, getTimeScale } from '../../utils/timeline';
-import { MAX_TICK_SPACING_PX } from '../../constants/timeline';
+import { MAX_TICK_SPACING_PX } from './_TimelinePeriodLabels';
 
 import Timeline from './_Timeline';
 import TimelinePanButton from './_TimelinePanButton';
@@ -376,6 +376,7 @@ class TimeTravel extends React.Component {
             earliestTimestamp={this.props.earliestTimestamp}
             durationMsPerPixel={this.state.durationMsPerPixel}
             rangeMs={this.state.rangeMs}
+            deployments={this.props.deployments}
             onJump={this.handleTimelineJump}
             onZoom={this.handleTimelineZoom}
             onPan={this.handleTimelinePan}
@@ -472,6 +473,10 @@ TimeTravel.propTypes = {
    * Optional callback handling range in milliseconds change
    */
   onChangeRange: PropTypes.func,
+  /**
+   * Optional list of deployment annotations shown in the timeline
+   */
+  deployments: PropTypes.array,
 };
 
 TimeTravel.defaultProps = {
@@ -487,6 +492,7 @@ TimeTravel.defaultProps = {
   onTimelineLabelClick: noop,
   onTimelineZoom: noop,
   onTimelinePan: noop,
+  deployments: [],
 };
 
 export default TimeTravel;

--- a/src/components/TimeTravel/_Timeline.js
+++ b/src/components/TimeTravel/_Timeline.js
@@ -12,7 +12,9 @@ import { Motion } from 'react-motion';
 import { strongSpring } from '../../utils/animation';
 import { formattedTimestamp, getTimeScale } from '../../utils/timeline';
 import { zoomFactor } from '../../utils/zooming';
+import theme from '../../theme';
 
+import TimelineDeployments from './_TimelineDeployments';
 import TimelinePeriodLabels from './_TimelinePeriodLabels';
 import TimelineRange from './_TimelineRange';
 
@@ -156,14 +158,14 @@ class Timeline extends React.PureComponent {
         />
 
         <TimelineRange
-          color="#aaa"
+          color={theme.colors.gray}
           width={width}
           height={height}
           endAt={this.props.earliestTimestamp}
           timeScale={timeScale}
         />
         <TimelineRange
-          color="#aaa"
+          color={theme.colors.gray}
           width={width}
           height={height}
           startAt={this.props.timestampNow}
@@ -171,7 +173,7 @@ class Timeline extends React.PureComponent {
         />
         {this.props.inspectingInterval && (
           <TimelineRange
-            color="#00d2ff"
+            color={theme.colors.accent.blue}
             width={width}
             height={height}
             startAt={startTimestamp}
@@ -179,6 +181,13 @@ class Timeline extends React.PureComponent {
             timeScale={timeScale}
           />
         )}
+
+        <TimelineDeployments
+          width={width}
+          height={height}
+          timeScale={timeScale}
+          deployments={this.props.deployments}
+        />
 
         <g className="ticks" transform="translate(0, 1)">
           {['year', 'month', 'day', 'minute'].map(period => (
@@ -252,6 +261,7 @@ Timeline.propTypes = {
   earliestTimestamp: PropTypes.string,
   durationMsPerPixel: PropTypes.number.isRequired,
   rangeMs: PropTypes.number.isRequired,
+  deployments: PropTypes.array.isRequired,
   onJump: PropTypes.func.isRequired,
   onZoom: PropTypes.func.isRequired,
   onPan: PropTypes.func.isRequired,

--- a/src/components/TimeTravel/_TimelineDeployments.js
+++ b/src/components/TimeTravel/_TimelineDeployments.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const MAX_VISIBLE_RANGE_SECS = moment.duration(2, 'weeks').asSeconds();
+
+// TODO: A lot of the code here has been taken/modified from PrometheusGraph code.
+// Abstract the common code.
+
+const DeploymentAnnotation = styled.g.attrs({
+  transform: ({ left }) => `translate(${left}, 0)`,
+})`
+  position: absolute;
+  top: 0;
+`;
+
+const VerticalLine = styled.line.attrs({
+  y2: ({ height }) => height,
+  stroke: ({ theme }) => theme.colors.accent.blue,
+  strokeWidth: 1,
+})`
+  pointer-events: none;
+  position: absolute;
+  opacity: 0.5;
+`;
+
+const FocusPoint = styled.circle.attrs({
+  r: ({ radius }) => radius,
+  fill: ({ theme }) => theme.colors.white,
+  transform: ({ height, radius }) => `translate(0, ${height - radius - 2})`,
+  stroke: ({ color, theme }) => color || theme.colors.accent.blue,
+  strokeWidth: 2,
+})`
+  position: absolute;
+  cursor: default;
+`;
+
+const formattedDeployments = ({ deployments, timeScale, width }) =>
+  deployments
+    .map(({ Data, Stamp }) => {
+      const [action, ...serviceIDs] = Data.split(', ');
+      return {
+        key: `${Data} --- ${Stamp}`,
+        position: timeScale(moment(Stamp)),
+        timestamp: moment(Stamp).format(),
+        serviceIDs,
+        action,
+      };
+    })
+    .filter(
+      ({ position }) =>
+        // Filter out all the deployments that fall out of the timeline.
+        -width / 2 <= position && position <= width / 2
+    );
+
+class TimelineDeployments extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      deployments: formattedDeployments(props),
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({ deployments: formattedDeployments(nextProps) });
+  }
+
+  render() {
+    const { height, timeScale } = this.props;
+
+    const [startTimeSec, endTimeSec] = timeScale.domain();
+    if (!startTimeSec || !endTimeSec) return null;
+
+    // Don't show deployment annotations if we've zoomed out too much.
+    // See https://github.com/weaveworks/service-ui/issues/1858.
+    if (endTimeSec - startTimeSec > MAX_VISIBLE_RANGE_SECS) return null;
+
+    return (
+      <g className="deployment-annotations">
+        {this.state.deployments.map(deployment => (
+          <DeploymentAnnotation key={deployment.key} left={deployment.position}>
+            <VerticalLine height={height} />
+            <FocusPoint radius="3" height={height} />
+            <title>{deployment.action}</title>
+          </DeploymentAnnotation>
+        ))}
+      </g>
+    );
+  }
+}
+
+TimelineDeployments.propTypes = {
+  width: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired,
+  timeScale: PropTypes.func.isRequired,
+  deployments: PropTypes.array.isRequired,
+};
+
+export default TimelineDeployments;

--- a/src/components/TimeTravel/_TimelineLabel.js
+++ b/src/components/TimeTravel/_TimelineLabel.js
@@ -9,7 +9,7 @@ const TimelineLabelContainer = styled.button`
   font-size: ${props => props.theme.fontSizes.small};
   cursor: pointer;
   margin-left: 2px;
-  padding: 3px;
+  padding: 0 1px;
   outline: 0;
   border: 0;
 

--- a/src/components/TimeTravel/_TimelinePeriodLabels.js
+++ b/src/components/TimeTravel/_TimelinePeriodLabels.js
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types';
 import { find, map, last, clamp } from 'lodash';
 
 import { formattedTimestamp, getTimeScale } from '../../utils/timeline';
-import { MAX_TICK_SPACING_PX } from '../../constants/timeline';
 
 import TimelineLabel from './_TimelineLabel';
 
+export const MAX_TICK_SPACING_PX = 415;
 const MAX_TICK_ROWS = 3;
 const MIN_TICK_SPACING_PX = 70;
 const TICKS_ROW_SPACING = 16;

--- a/src/components/TimeTravel/example.js
+++ b/src/components/TimeTravel/example.js
@@ -1,8 +1,22 @@
 import React from 'react';
+import faker from 'faker';
 import moment from 'moment';
+import { compact, times } from 'lodash';
 
 import TimeTravel from '.';
 import { Example, Info } from '../../utils/example';
+
+function generateDeployments({ startTime, endTime }, count) {
+  return times(count, () => ({
+    Stamp: moment.unix(faker.random.number({ min: startTime, max: endTime })),
+    Data: compact([
+      `Commit: ${faker.lorem.word()}`,
+      Math.random() < 0.5 && faker.lorem.slug(),
+      Math.random() < 0.5 && faker.lorem.slug(),
+      Math.random() < 0.5 && faker.lorem.slug(),
+    ]).join(', '),
+  }));
+}
 
 export default class TimeTravelExample extends React.Component {
   constructor() {
@@ -11,31 +25,35 @@ export default class TimeTravelExample extends React.Component {
     this.state = {
       timestamp1: moment().format(),
       timestamp2: moment().format(),
-      showingLive2: true,
-      rangeMs2: 3600000,
+      timestamp3: moment().format(),
+      showingLive3: true,
+      rangeMs3: 3600000,
+      deployments: generateDeployments({
+        startTime: moment().subtract(1, 'month').unix(),
+        endTime: moment().unix(),
+      }, 500),
     };
-
-    this.handleChangeTimestamp1 = this.handleChangeTimestamp1.bind(this);
-    this.handleChangeTimestamp2 = this.handleChangeTimestamp2.bind(this);
-    this.handleChangeLiveMode2 = this.handleChangeLiveMode2.bind(this);
-    this.handleChangeRange2 = this.handleChangeRange2.bind(this);
   }
 
-  handleChangeTimestamp1(timestamp1) {
+  handleChangeTimestamp1 = (timestamp1) => {
     this.setState({ timestamp1 });
-  }
+  };
 
-  handleChangeTimestamp2(timestamp2) {
+  handleChangeTimestamp2 = (timestamp2) => {
     this.setState({ timestamp2 });
-  }
+  };
 
-  handleChangeLiveMode2(showingLive2) {
-    this.setState({ showingLive2 });
-  }
+  handleChangeTimestamp3 = (timestamp3) => {
+    this.setState({ timestamp3 });
+  };
 
-  handleChangeRange2(rangeMs2) {
-    this.setState({ rangeMs2 });
-  }
+  handleChangeLiveMode3 = (showingLive3) => {
+    this.setState({ showingLive3 });
+  };
+
+  handleChangeRange3 = (rangeMs3) => {
+    this.setState({ rangeMs3 });
+  };
 
   render() {
     return (
@@ -48,16 +66,24 @@ export default class TimeTravelExample extends React.Component {
           />
         </Example>
         <Example>
-          <Info>Range selector with live mode support</Info>
+          <Info>With deployments</Info>
           <TimeTravel
             timestamp={this.state.timestamp2}
             onChangeTimestamp={this.handleChangeTimestamp2}
+            deployments={this.state.deployments}
+          />
+        </Example>
+        <Example>
+          <Info>Range selector with live mode support</Info>
+          <TimeTravel
+            timestamp={this.state.timestamp3}
+            onChangeTimestamp={this.handleChangeTimestamp3}
             hasLiveMode
-            showingLive={this.state.showingLive2}
-            onChangeLiveMode={this.handleChangeLiveMode2}
+            showingLive={this.state.showingLive3}
+            onChangeLiveMode={this.handleChangeLiveMode3}
             hasRangeSelector
-            rangeMs={this.state.rangeMs2}
-            onChangeRange={this.handleChangeRange2}
+            rangeMs={this.state.rangeMs3}
+            onChangeRange={this.handleChangeRange3}
           />
         </Example>
       </div>

--- a/src/constants/timeline.js
+++ b/src/constants/timeline.js
@@ -1,1 +1,0 @@
-export const MAX_TICK_SPACING_PX = 415;


### PR DESCRIPTION
Add support for https://github.com/weaveworks/service-ui/issues/1856.

The next step is to send the pass through deployments info from all the relevant places in Service UI.

![image](https://user-images.githubusercontent.com/1216874/40372650-703cf5ee-5de5-11e8-9e26-3430676aeccc.png)

**Note:** Deployment annotations sometimes overlap with timestamp labels - @bia and I thought it's ok to ignore that issue for the moment and address it in https://github.com/weaveworks/ui-components/issues/226 instead.
