### PR TITLE
Add TimeTravel callback for visible range change

### DIFF
--- a/src/components/TimeTravel/TimeTravel.js
+++ b/src/components/TimeTravel/TimeTravel.js
@@ -382,6 +382,7 @@ class TimeTravel extends React.Component {
             onPan={this.handleTimelinePan}
             onRelease={this.handleTimelineRelease}
             onResize={this.handleTimelineResize}
+            onUpdateVisibleRange={this.props.onUpdateVisibleRange}
           />
           <TimelinePanButton
             icon="fa fa-chevron-right"
@@ -477,6 +478,10 @@ TimeTravel.propTypes = {
    * Optional list of deployment annotations shown in the timeline
    */
   deployments: PropTypes.array,
+  /**
+   * Optional callback when visible part of the timeline gets updated
+   */
+  onUpdateVisibleRange: PropTypes.func,
 };
 
 TimeTravel.defaultProps = {
@@ -493,6 +498,7 @@ TimeTravel.defaultProps = {
   onTimelineZoom: noop,
   onTimelinePan: noop,
   deployments: [],
+  onUpdateVisibleRange: noop,
 };
 
 export default TimeTravel;

--- a/src/components/TimeTravel/example.js
+++ b/src/components/TimeTravel/example.js
@@ -3,6 +3,7 @@ import faker from 'faker';
 import moment from 'moment';
 import { compact, times } from 'lodash';
 
+import Text from '../Text';
 import TimeTravel from '.';
 import { Example, Info } from '../../utils/example';
 
@@ -28,6 +29,8 @@ export default class TimeTravelExample extends React.Component {
       timestamp3: moment().format(),
       showingLive3: true,
       rangeMs3: 3600000,
+      visibleStartAt: null,
+      visibleEndAt: null,
       deployments: generateDeployments({
         startTime: moment().subtract(1, 'month').unix(),
         endTime: moment().unix(),
@@ -55,6 +58,13 @@ export default class TimeTravelExample extends React.Component {
     this.setState({ rangeMs3 });
   };
 
+  handleUpdateVisibleRange = ({ startAt, endAt }) => {
+    this.setState({
+      visibleStartAt: startAt,
+      visibleEndAt: endAt,
+    });
+  }
+
   render() {
     return (
       <div>
@@ -63,6 +73,7 @@ export default class TimeTravelExample extends React.Component {
           <TimeTravel
             timestamp={this.state.timestamp1}
             onChangeTimestamp={this.handleChangeTimestamp1}
+            onUpdateVisibleRange={this.handleUpdateVisibleRange}
           />
         </Example>
         <Example>
@@ -70,6 +81,7 @@ export default class TimeTravelExample extends React.Component {
           <TimeTravel
             timestamp={this.state.timestamp2}
             onChangeTimestamp={this.handleChangeTimestamp2}
+            onUpdateVisibleRange={this.handleUpdateVisibleRange}
             deployments={this.state.deployments}
           />
         </Example>
@@ -84,8 +96,13 @@ export default class TimeTravelExample extends React.Component {
             hasRangeSelector
             rangeMs={this.state.rangeMs3}
             onChangeRange={this.handleChangeRange3}
+            onUpdateVisibleRange={this.handleUpdateVisibleRange}
           />
         </Example>
+        <hr />
+        <Text small>
+          Visible range: {this.state.visibleStartAt} - {this.state.visibleEndAt}
+        </Text>
       </div>
     );
   }


### PR DESCRIPTION
Follow-up to #227, needed for knowing which time interval to query for deployments in https://github.com/weaveworks/service-ui/issues/1856.

See the `TimeTravel` component example for testing:

![image](https://user-images.githubusercontent.com/1216874/40491342-17845854-5f6e-11e8-8be1-0d8b71bdcebf.png)
