### PR TITLE
Add blinking timeline loader

### DIFF
--- a/src/components/TimeTravel/TimeTravel.js
+++ b/src/components/TimeTravel/TimeTravel.js
@@ -151,25 +151,11 @@ class TimeTravel extends React.Component {
       timelineWidthPx: null,
     };
 
-    this.handleTimelinePanButtonClick = this.handleTimelinePanButtonClick.bind(
-      this
-    );
-    this.handleTimelineJump = this.handleTimelineJump.bind(this);
-    this.handleTimelineZoom = this.handleTimelineZoom.bind(this);
-    this.handleTimelinePan = this.handleTimelinePan.bind(this);
-    this.handleTimelineRelease = this.handleTimelineRelease.bind(this);
-    this.handleTimelineResize = this.handleTimelineResize.bind(this);
-    this.handleRangeChange = this.handleRangeChange.bind(this);
-    this.handleInputChange = this.handleInputChange.bind(this);
-    this.handleLiveModeToggle = this.handleLiveModeToggle.bind(this);
-
-    this.delayedReportZoom = debounce(this.reportZoom.bind(this), 5000);
+    this.delayedReportZoom = debounce(this.reportZoom, 5000);
     this.delayedOnChangeTimestamp = debounce(
-      this.props.onChangeTimestamp.bind(this),
+      this.props.onChangeTimestamp,
       500
     );
-
-    this.setFocusedTimestamp = this.setFocusedTimestamp.bind(this);
   }
 
   componentDidMount() {
@@ -237,25 +223,25 @@ class TimeTravel extends React.Component {
     );
   }
 
-  handleRangeChange(rangeMs) {
+  handleRangeChange = (rangeMs) => {
     this.setState({ rangeMs });
     this.adjustZoomToRange(rangeMs, this.state.timelineWidthPx);
     this.props.onChangeRange(rangeMs);
   }
 
-  handleInputChange(timestamp) {
+  handleInputChange = (timestamp) => {
     this.setFocusedTimestamp(timestamp);
     this.props.onTimestampInputEdit();
   }
 
-  handleTimelineJump(timestamp) {
+  handleTimelineJump = (timestamp) => {
     //  Order of callbacks is important.
     this.switchToPausedMode();
     this.setFocusedTimestamp(timestamp);
     this.props.onTimelineLabelClick();
   }
 
-  handleTimelinePanButtonClick(timestamp) {
+  handleTimelinePanButtonClick = (timestamp) => {
     if (this.shouldStickySwitchToLiveMode({ focusedTimestamp: timestamp })) {
       //  Order of callbacks is important.
       this.setFocusedTimestamp(this.state.timestampNow);
@@ -268,13 +254,13 @@ class TimeTravel extends React.Component {
     this.props.onTimelinePanButtonClick();
   }
 
-  handleTimelineZoom(duration) {
+  handleTimelineZoom = (duration) => {
     const durationMsPerPixel = this.clampedDuration(duration);
     this.setState({ durationMsPerPixel });
     this.delayedReportZoom();
   }
 
-  handleTimelinePan(timestamp) {
+  handleTimelinePan = (timestamp) => {
     //  Order of callbacks is important.
     const focusedTimestamp = this.clampedTimestamp(timestamp);
     this.switchToPausedMode();
@@ -282,7 +268,7 @@ class TimeTravel extends React.Component {
     this.delayedOnChangeTimestamp(focusedTimestamp);
   }
 
-  handleTimelineRelease() {
+  handleTimelineRelease = () => {
     if (this.shouldStickySwitchToLiveMode()) {
       //  Order of callbacks is important.
       this.setFocusedTimestamp(this.state.timestampNow);
@@ -291,7 +277,7 @@ class TimeTravel extends React.Component {
     this.props.onTimelinePan();
   }
 
-  handleTimelineResize(timelineWidthPx) {
+  handleTimelineResize = (timelineWidthPx) => {
     // If this is the initial resize, adjust the zoom level to the current selected range.
     if (!this.state.timelineWidthPx) {
       this.adjustZoomToRange(this.state.rangeMs, timelineWidthPx);
@@ -299,7 +285,7 @@ class TimeTravel extends React.Component {
     this.setState({ timelineWidthPx });
   }
 
-  handleLiveModeToggle(showingLive) {
+  handleLiveModeToggle = (showingLive) => {
     if (showingLive) {
       //  Order of callbacks is important.
       this.setState({ focusedTimestamp: this.state.timestampNow });
@@ -309,21 +295,21 @@ class TimeTravel extends React.Component {
     }
   }
 
-  switchToLiveMode() {
+  switchToLiveMode = () => {
     if (this.props.hasLiveMode && !this.state.showingLive) {
       this.setState({ showingLive: true });
       this.props.onChangeLiveMode(true);
     }
   }
 
-  switchToPausedMode() {
+  switchToPausedMode = () => {
     if (this.props.hasLiveMode && this.state.showingLive) {
       this.setState({ showingLive: false });
       this.props.onChangeLiveMode(false);
     }
   }
 
-  setFocusedTimestamp(timestamp) {
+  setFocusedTimestamp = (timestamp) => {
     const focusedTimestamp = this.clampedTimestamp(timestamp);
     if (focusedTimestamp !== this.state.focusedTimestamp) {
       this.delayedOnChangeTimestamp.cancel();
@@ -332,13 +318,13 @@ class TimeTravel extends React.Component {
     }
   }
 
-  adjustZoomToRange(rangeMs, timelineWidthPx) {
+  adjustZoomToRange = (rangeMs, timelineWidthPx) => {
     const rawDurationMsPerPixel = rangeMs / (timelineWidthPx / 3);
     const durationMsPerPixel = this.clampedDuration(rawDurationMsPerPixel);
     this.setState({ durationMsPerPixel });
   }
 
-  reportZoom() {
+  reportZoom = () => {
     const periods = [
       'years',
       'months',
@@ -377,6 +363,7 @@ class TimeTravel extends React.Component {
             durationMsPerPixel={this.state.durationMsPerPixel}
             rangeMs={this.state.rangeMs}
             deployments={this.props.deployments}
+            isLoading={this.props.isLoading}
             onJump={this.handleTimelineJump}
             onZoom={this.handleTimelineZoom}
             onPan={this.handleTimelinePan}
@@ -482,6 +469,10 @@ TimeTravel.propTypes = {
    * Optional callback when visible part of the timeline gets updated
    */
   onUpdateVisibleRange: PropTypes.func,
+  /**
+   * Shows timeline loading indicator
+   */
+  isLoading: PropTypes.bool,
 };
 
 TimeTravel.defaultProps = {
@@ -491,13 +482,14 @@ TimeTravel.defaultProps = {
   onChangeLiveMode: noop,
   hasRangeSelector: false,
   rangeMs: 3600000, // 1 hour as a default, only relevant if range selector is enabled
+  deployments: [],
+  isLoading: false,
   onChangeRange: noop,
   onTimestampInputEdit: noop,
   onTimelinePanButtonClick: noop,
   onTimelineLabelClick: noop,
   onTimelineZoom: noop,
   onTimelinePan: noop,
-  deployments: [],
   onUpdateVisibleRange: noop,
 };
 

--- a/src/components/TimeTravel/_TimelineDeployments.js
+++ b/src/components/TimeTravel/_TimelineDeployments.js
@@ -14,22 +14,23 @@ const DeploymentAnnotation = styled.span.attrs({
   style: ({ x }) => ({ transform: `translateX(${x}px)` }),
 })`
   position: absolute;
+  height: 100%;
   top: 0;
 `;
 
 const VerticalLine = styled.span`
   border-left: 1px solid ${props => props.theme.colors.accent.blue};
-  height: ${props => props.height}px;
   pointer-events: none;
   position: absolute;
   opacity: 0.5;
+  height: 100%;
 `;
 
 const FocusPoint = styled.span`
+  bottom: 0;
+  left: ${props => -props.radius - 2}px;
   width: ${props => 2 * props.radius}px;
   height: ${props => 2 * props.radius}px;
-  margin-left: ${props => -props.radius - 2}px;
-  margin-top: ${props => props.height - (2 * props.radius) - 4}px;
   background-color: ${props => props.theme.colors.white};
   border: 2px solid ${props => props.theme.colors.accent.blue};
   border-radius: ${props => props.theme.borderRadius.circle};
@@ -69,7 +70,7 @@ class TimelineDeployments extends React.PureComponent {
   }
 
   render() {
-    const { height, timeScale } = this.props;
+    const { timeScale } = this.props;
 
     const [startTimeSec, endTimeSec] = timeScale.domain();
     if (!startTimeSec || !endTimeSec) return null;
@@ -86,8 +87,8 @@ class TimelineDeployments extends React.PureComponent {
             x={deployment.position}
             title={deployment.action}
           >
-            <VerticalLine height={height} />
-            <FocusPoint radius="2" height={height} />
+            <VerticalLine />
+            <FocusPoint radius="2" />
           </DeploymentAnnotation>
         ))}
       </DeploymentAnnotations>
@@ -97,7 +98,6 @@ class TimelineDeployments extends React.PureComponent {
 
 TimelineDeployments.propTypes = {
   width: PropTypes.number.isRequired,
-  height: PropTypes.number.isRequired,
   timeScale: PropTypes.func.isRequired,
   deployments: PropTypes.array.isRequired,
 };

--- a/src/components/TimeTravel/_TimelineLoader.js
+++ b/src/components/TimeTravel/_TimelineLoader.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import moment from 'moment';
+import styled, { keyframes } from 'styled-components';
+import PropTypes from 'prop-types';
+
+// NOTE (fbarl): For some reason, doing the animation with
+// opacity looks buggy on my Chrome on deep zoom levels.
+/* stylelint-disable color-no-hex */
+const blinking = keyframes`
+  0% {
+    background-color: #fff;
+  }
+  50% {
+    background-color: transparent;
+  }
+  100% {
+    background-color: #fff;
+  }
+`;
+/* stylelint-enable color-no-hex */
+
+const TimelineLoaderOverlay = styled.div.attrs({
+  style: ({ x, width }) => ({
+    left: `${x}px`,
+    width,
+  })
+})`
+  animation: ${blinking} 2s linear infinite;
+  pointer-events: none;
+  position: absolute;
+  opacity: 0.65;
+  height: 100%;
+`;
+
+const TimelineLoader = ({ timeScale, startAt, endAt, width }) => {
+  const endShift = endAt ? Math.min(timeScale(moment(endAt)), width) : width;
+  const startShift = startAt ? Math.max(timeScale(moment(startAt)), -width) : -width;
+  const length = endShift - startShift;
+
+  return (
+    <TimelineLoaderOverlay x={startShift} width={length} />
+  );
+};
+
+TimelineLoader.propTypes = {
+  timeScale: PropTypes.func.isRequired,
+  startAt: PropTypes.string,
+  endAt: PropTypes.string,
+  width: PropTypes.number.isRequired,
+};
+
+export default TimelineLoader;

--- a/src/components/TimeTravel/_TimelineRange.js
+++ b/src/components/TimeTravel/_TimelineRange.js
@@ -4,20 +4,20 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
 const TimelineRangeOverlay = styled.div.attrs({
-  style: ({ x, width, height }) => ({
+  style: ({ x, width }) => ({
     transform: `translateX(${x}px)`,
     width,
-    height,
   })
 })`
   background-color: ${props => props.color};
   position: absolute;
   opacity: 0.15;
+  height: 100%;
 `;
 
-const TimelineRange = ({ color, timeScale, startAt, endAt, width, height }) => {
-  const endShift = endAt ? timeScale(moment(endAt)) : width;
-  let startShift = startAt ? timeScale(moment(startAt)) : -width;
+const TimelineRange = ({ color, timeScale, startAt, endAt, width }) => {
+  const endShift = endAt ? Math.min(timeScale(moment(endAt)), width) : width;
+  let startShift = startAt ? Math.max(timeScale(moment(startAt)), -width) : -width;
 
   // If the range interval is very short or we're zoomed out a lot, render the
   // interval as at least 4 pixels wide. Then re-adjust the left end of the
@@ -26,7 +26,7 @@ const TimelineRange = ({ color, timeScale, startAt, endAt, width, height }) => {
   startShift = endShift - length;
 
   return (
-    <TimelineRangeOverlay color={color} x={startShift} width={length} height={height} />
+    <TimelineRangeOverlay color={color} x={startShift} width={length} />
   );
 };
 
@@ -36,7 +36,6 @@ TimelineRange.propTypes = {
   startAt: PropTypes.string,
   endAt: PropTypes.string,
   width: PropTypes.number.isRequired,
-  height: PropTypes.number.isRequired,
 };
 
 export default TimelineRange;

--- a/src/components/TimeTravel/example.js
+++ b/src/components/TimeTravel/example.js
@@ -20,13 +20,14 @@ function generateDeployments({ startTime, endTime }, count) {
 }
 
 export default class TimeTravelExample extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       timestamp1: moment().format(),
       timestamp2: moment().format(),
       timestamp3: moment().format(),
+      isLoading2: false,
       showingLive3: true,
       rangeMs3: 3600000,
       visibleStartAt: null,
@@ -43,7 +44,11 @@ export default class TimeTravelExample extends React.Component {
   };
 
   handleChangeTimestamp2 = (timestamp2) => {
-    this.setState({ timestamp2 });
+    this.setState({ timestamp2, isLoading2: true });
+    // Show loading indicator for 5 seconds after every timestamp change..
+    setTimeout(() => {
+      this.setState({ isLoading2: false });
+    }, 5000);
   };
 
   handleChangeTimestamp3 = (timestamp3) => {
@@ -79,6 +84,7 @@ export default class TimeTravelExample extends React.Component {
         <Example>
           <Info>With deployments</Info>
           <TimeTravel
+            isLoading={this.state.isLoading2}
             timestamp={this.state.timestamp2}
             onChangeTimestamp={this.handleChangeTimestamp2}
             onUpdateVisibleRange={this.handleUpdateVisibleRange}


### PR DESCRIPTION
Resolves #229 by showing a semi-transparent blinking overlay over the _free_ timeline area as discussed with @bia.

##### Other changes

* Moved away from function `.bind(this)` syntax in a couple of places
* Used `height: 100%` in a couple of places instead of passing the timeline height prop
* Simplified the way deployment annotations are rendered
* Always capping all timeline ranges to the visible chunk of the timeline

**Note:** Test this by panning around the second timeline in the example (the one with deployments).

![image](https://user-images.githubusercontent.com/1216874/40793222-224f93c8-64fc-11e8-8968-f75b3bd904d0.png)
