### PR TITLE
Allow customizing toggle view for Dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -82,6 +82,16 @@ const StyledDropdown = component => styled(component)`
   width: ${WIDTH};
 `;
 
+
+const DefaultToggleView = ({ onClick, selectedLabel }) => (
+  <SelectedItem onClick={onClick}>
+    <Item>{selectedLabel}</Item>
+    <div>
+      <SelectedItemIcon className="fa fa-caret-down" />
+    </div>
+  </SelectedItem>);
+
+
 /**
  * A selectable drop-down menu.
  * ```javascript
@@ -121,7 +131,6 @@ const StyledDropdown = component => styled(component)`
  * ];
  * ```
  */
-
 class Dropdown extends React.Component {
   constructor(props, context) {
     super(props, context);
@@ -168,15 +177,12 @@ class Dropdown extends React.Component {
       (placeholder
         ? { label: placeholder, value: null }
         : divided && divided[0]);
+    const label = currentItem && currentItem.label;
+    const Component = this.props.withComponent;
 
     return (
-      <div className={className} title={currentItem && currentItem.label}>
-        <SelectedItem onClick={this.handleClick}>
-          <Item>{currentItem && currentItem.label}</Item>
-          <div>
-            <SelectedItemIcon className="fa fa-caret-down" />
-          </div>
-        </SelectedItem>
+      <div className={className} title={label}>
+        <Component selectedLabel={label} onClick={this.handleClick} />
         {isOpen && (
           <div>
             <Overlay onClick={this.handleBgClick} />
@@ -233,6 +239,17 @@ Dropdown.propTypes = {
    * The initial text that will be display before a user selects an item.
    */
   placeholder: PropTypes.string,
+
+  /**
+   * A custom component to replace the default toggle view.
+   * The properties `selectedLabel` and `onClick` are provided. `onClick` needs to be incorporated
+   * to make the dropdown list toggle.
+   */
+  withComponent: PropTypes.func,
+};
+
+Dropdown.defaultProps = {
+  withComponent: DefaultToggleView,
 };
 
 export default StyledDropdown(Dropdown);

--- a/src/components/Dropdown/example.js
+++ b/src/components/Dropdown/example.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Example, Info } from '../../utils/example';
 import { Grid, GridRow as Row, GridColumn as Column } from '../Grid';
+import Button from '../Button';
 
 import Dropdown from '.';
 
@@ -55,6 +56,10 @@ const divided = [
   },
 ];
 
+const DropdownButton = ({ onClick }) => (
+  <Button onClick={onClick}>More actions <i className="fa fa-caret-down" /></Button>
+);
+
 export default class DropdownExample extends React.Component {
   constructor() {
     super();
@@ -97,6 +102,19 @@ export default class DropdownExample extends React.Component {
               <Dropdown
                 items={items}
                 placeholder="Select an item"
+                value={this.state.selected}
+                onChange={this.handleChange}
+              />
+            </Example>
+          </Column>
+        </Row>
+        <Row>
+          <Column span={6}>
+            <Example>
+              <Info>With <code>Button</code> component</Info>
+              <Dropdown
+                withComponent={DropdownButton}
+                items={divided}
                 value={this.state.selected}
                 onChange={this.handleChange}
               />


### PR DESCRIPTION
Adds the prop `withComponent` to give the ability to replace the default
toggle view.

Closes #221 