### PR TITLE
if user manually sets legend, use that over props

### DIFF
--- a/src/components/PrometheusGraph/PrometheusGraph.js
+++ b/src/components/PrometheusGraph/PrometheusGraph.js
@@ -210,6 +210,7 @@ class PrometheusGraph extends React.PureComponent {
     this.state = {
       multiSeries: [],
       selectedLegendKeys: props.selectedLegendKeys,
+      selectedLegendOverride: false,
       hoveredLegendKey: null,
       hoverTimestampSec: null,
       hoverPoints: null,
@@ -228,7 +229,10 @@ class PrometheusGraph extends React.PureComponent {
     if (this.props.multiSeries !== nextProps.multiSeries) {
       this.prepareMultiSeries(nextProps);
     }
-    if (this.props.selectedLegendKeys !== nextProps.selectedLegendKeys) {
+    if (
+      this.props.selectedLegendKeys !== nextProps.selectedLegendKeys &&
+      !this.state.selectedLegendOverride
+    ) {
       const { selectedLegendKeys } = nextProps;
       this.prepareMultiSeries(nextProps, { selectedLegendKeys });
       this.setState({ selectedLegendKeys });
@@ -237,7 +241,7 @@ class PrometheusGraph extends React.PureComponent {
 
   handleSelectedLegendKeysChange = selectedLegendKeys => {
     this.prepareMultiSeries(this.props, { selectedLegendKeys });
-    this.setState({ selectedLegendKeys });
+    this.setState({ selectedLegendKeys, selectedLegendOverride: true });
     this.props.onChangeLegendSelection(selectedLegendKeys);
   };
 


### PR DESCRIPTION
when passing `selectedLegendKeys` props and then selecting another
legend, the legend will reset when the component re-renders.
this PR sets a flag when the user has manually selected a label not to
be overridden on re-render

Needed as part of https://github.com/weaveworks/service-ui/pull/2676 