### PR TITLE
add secondary styling for TabSelect

### DIFF
--- a/src/components/TabSelect/TabSelect.js
+++ b/src/components/TabSelect/TabSelect.js
@@ -8,16 +8,23 @@ import TabButton from './_TabButton';
 
 const TabButtons = styled.div``;
 
-const TabContent = styled.div`
-  padding: 20px;
-  background-color: ${props => props.theme.colors.white};
-
-  ${props => `
+const borders = props => `
     border-top-right-radius: ${props.theme.borderRadius.soft};
     border-bottom-right-radius: ${props.theme.borderRadius.soft};
     border-bottom-left-radius: ${props.theme.borderRadius.soft};
     border: 1px solid ${props.theme.colors.athens};
-  `};
+`;
+
+const bordersOnlyTop = props => `
+  border-top: 1px solid ${props.theme.colors.athens}
+`;
+
+const TabContent = styled.div`
+  padding: 20px;
+  background-color: ${props =>
+    props.secondary ? props.theme.colors.sand : props.theme.colors.white};
+
+  ${props => (props.secondary ? bordersOnlyTop(props) : borders(props))};
 `;
 
 const Styled = component => styled(component)``;
@@ -48,7 +55,7 @@ class TabSelect extends React.PureComponent {
   };
 
   render() {
-    const { className, children } = this.props;
+    const { className, children, secondary } = this.props;
     const tabs = React.Children.map(children, child =>
       pick(child.props, ['label', 'name'])
     );
@@ -63,19 +70,25 @@ class TabSelect extends React.PureComponent {
               key={tab.name}
               name={tab.name}
               selected={this.isSelectedTab(tab)}
+              secondary={secondary}
               onClick={this.handleTabClick}
             >
               {tab.label}
             </TabButton>
           ))}
         </TabButtons>
-        <TabContent>{selected}</TabContent>
+        <TabContent secondary={secondary}>{selected}</TabContent>
       </div>
     );
   }
 }
 
 TabSelect.propTypes = {
+  /**
+   * Secondary styling for TabSelect without border around content and
+   * transparent background
+   */
+  secondary: PropTypes.bool,
   /**
    * The tab to show on first render.
    * Supplying a new value to this prop will override the currently selected item
@@ -97,6 +110,10 @@ TabSelect.propTypes = {
     });
     return error;
   },
+};
+
+TabSelect.defaultProps = {
+  secondary: false,
 };
 
 export default Styled(TabSelect);

--- a/src/components/TabSelect/_TabButton.js
+++ b/src/components/TabSelect/_TabButton.js
@@ -3,6 +3,14 @@ import styled from 'styled-components';
 
 const TabName = styled.span``;
 
+const getBgColor = (selected, secondary, theme) => {
+  if (secondary) {
+    return theme.colors.sand;
+  }
+
+  return selected ? theme.colors.white : theme.colors.lightgray;
+};
+
 const Styled = component => styled(component)`
   cursor: pointer;
   margin-bottom: -1px;
@@ -11,8 +19,8 @@ const Styled = component => styled(component)`
   font-size: ${props => props.theme.fontSizes.large};
   outline: 0;
 
-  ${({ selected, theme }) => `
-    background-color: ${selected ? theme.colors.white : theme.colors.lightgray};
+  ${({ selected, secondary, theme }) => `
+    background-color: ${getBgColor(selected, secondary, theme)};
     border-top-left-radius: ${theme.borderRadius.soft};
     border-top-right-radius: ${theme.borderRadius.soft};
     border: 1px solid ${theme.colors.athens};

--- a/src/components/TabSelect/example.js
+++ b/src/components/TabSelect/example.js
@@ -1,23 +1,40 @@
 import React from 'react';
 
-import { Example } from '../../utils/example';
+import { Example, Info } from '../../utils/example';
 import TabSelect from './TabSelect';
 import Tab from './Tab';
 
 export default function TabSelectExample() {
   return (
-    <Example>
-      <TabSelect>
-        <Tab label="A" name="a">
-          Tab A
-        </Tab>
-        <Tab label="B" name="b">
-          Tab B
-        </Tab>
-        <Tab label="C" name="c">
-          Tab C
-        </Tab>
-      </TabSelect>
-    </Example>
+    <div>
+      <Example>
+        <Info>Default</Info>
+        <TabSelect>
+          <Tab label="A" name="a">
+            Tab A
+          </Tab>
+          <Tab label="B" name="b">
+            Tab B
+          </Tab>
+          <Tab label="C" name="c">
+            Tab C
+          </Tab>
+        </TabSelect>
+      </Example>
+      <Info>Secondary</Info>
+      <Example>
+        <TabSelect secondary>
+          <Tab label="A" name="a">
+            Tab A
+          </Tab>
+          <Tab label="B" name="b">
+            Tab B
+          </Tab>
+          <Tab label="C" name="c">
+            Tab C
+          </Tab>
+        </TabSelect>
+      </Example>
+    </div>
   );
 }


### PR DESCRIPTION
Currently uses `theme.colors.sand` which is the background used across the site. Unsure if there are needs for different backgrounds in which case we can make this configurable?

![image](https://user-images.githubusercontent.com/1794071/41228818-9160abb2-6d71-11e8-9542-07df1437475f.png)


Fixes #251