### PR TITLE
add Code component for showing/copying snippets

### DIFF
--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -1,0 +1,150 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { isFunction, isString, trim, noop } from 'lodash';
+
+const CopyNotice = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 10px 15px;
+  border-radius: ${props => props.theme.borderRadius.soft};
+  background-color: ${props => props.theme.colors.purple800};
+  transition: opacity 300ms ease;
+  opacity: 0;
+  font-size: ${props => props.theme.fontSizes.small};
+  color: ${props => props.theme.colors.purple50};
+`;
+
+const CodeWrapper = styled.div`
+  position: relative;
+  padding: 10px 15px;
+  background-color: ${props => props.theme.colors.purple800};
+  box-sizing: border-box;
+  border-radius: ${props => props.theme.borderRadius.soft};
+  cursor: pointer;
+
+  &:hover ${CopyNotice} {
+    opacity: 0.9;
+  }
+`;
+
+const Content = styled.div`
+  flex-grow: 1;
+  overflow: auto;
+  color: ${props => props.theme.colors.purple50};
+`;
+
+const Pre = styled.pre`
+  margin: 10px 0;
+  font-family: ${props => props.theme.fontFamilies.monospace};
+  font-size: ${props => props.theme.fontSizes.small};
+`;
+
+const trimString = node => (isString(node) ? trim(node) : node);
+
+/**
+ * Code allows for easy rendering of code snippets which can easliy be copied to
+ * the clipboard by clicking the element or selecting a portion of the code
+ */
+class Code extends Component {
+  static displayName = 'Code';
+
+  state = {
+    isCopying: false,
+  };
+
+  componentDidUpdate = () => {
+    // reselect text after re-render
+    if (this.state.selectedRange) {
+      const prevRange = this.state.selectedRange;
+      const sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(prevRange);
+      // clear it for the next interaction
+      this.setState({ selectedRange: null });
+    }
+  };
+
+  handleCopyClick = () => {
+    // Create a textarea element in which the text of the code will be copied.
+    // Set the value of the textarea, select it to set it as the active element,
+    // then copy the value of that element to the clipboard.
+    // It's 2017 and this is still the best way to copy text on button click...
+    if (isFunction(this.props.onCopy)) {
+      this.props.onCopy();
+    }
+    const selection = document.getSelection();
+    const selectionString = selection.toString();
+    // if user has selected text, save that to state so it can be reselected
+    if (selectionString !== '') {
+      this.setState({
+        selectedRange: selection.getRangeAt(0),
+      });
+    }
+    // console.dir(document.getSelection().anchorNode);
+    const code =
+      selectionString === '' ? this.preNode.textContent : selectionString;
+    const txtArea = document.createElement('textarea');
+    // Safari doesn't allow for assigning an object literal to `style`.
+    txtArea.class = 'hidden-textarea';
+    // Make sure the code ends in a newline to execute all the commands in multiline code.
+    if (code.charAt(code.length - 1) === '\n') {
+      txtArea.value = code;
+    } else {
+      txtArea.value = `${code}\n`;
+    }
+    document.body.appendChild(txtArea);
+
+    txtArea.select();
+
+    try {
+      document.execCommand('copy');
+    } catch (e) {
+      throw e;
+    }
+    document.body.removeChild(txtArea);
+
+    // show the Copied to clipboard notice temporarily
+    this.setState({ isCopying: true });
+    setTimeout(() => {
+      this.setState({ isCopying: false });
+    }, 3000);
+  };
+
+  render() {
+    const { children } = this.props;
+    const { isCopying } = this.state;
+
+    const copyText = isCopying ? 'Copied to clipboard' : 'Copy to clipboard';
+    const copyIcon = isCopying ? 'files-o' : 'check';
+
+    return (
+      <CodeWrapper onClick={this.handleCopyClick}>
+        <Content>
+          <Pre innerRef={e => (this.preNode = e)}>
+            {isFunction(children) ? children() : trimString(children)}
+          </Pre>
+        </Content>
+
+        <CopyNotice>
+          <i className={`fa fa-${copyIcon}`} /> {copyText}
+        </CopyNotice>
+      </CodeWrapper>
+    );
+  }
+}
+
+Code.propTypes = {
+  // Children can be anything that React can render
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+
+  // onCopy will be called when the CodeWrapper is clicked
+  onCopy: PropTypes.func,
+};
+
+Code.defaultProps = {
+  onCopy: noop,
+};
+
+export default Code;

--- a/src/components/Code/Code.test.js
+++ b/src/components/Code/Code.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import enzyme, { shallow, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { withTheme } from '../../utils/theme';
+import Code from '.';
+
+enzyme.configure({ adapter: new Adapter() });
+
+document.execCommand = () => {};
+document.getSelection = () => ({
+  toString: () => '',
+});
+
+describe('<Code />', () => {
+  let props;
+  let wrapper;
+  let onCopy;
+
+  beforeEach(() => {
+    onCopy = jest.fn();
+    props = {
+      onCopy,
+    };
+    wrapper = shallow(
+      withTheme(<Code {...props}>such code much programming</Code>)
+    );
+  });
+
+  it('should call onCopy when the button is clicked', () => {
+    wrapper = mount(
+      withTheme(<Code {...props}>such code much programming</Code>)
+    );
+    expect(onCopy).not.toHaveBeenCalled();
+    wrapper.find('Code__CopyNotice').simulate('click');
+    expect(onCopy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render correctly', () => {
+    expect(wrapper.dive()).toMatchSnapshot();
+  });
+});

--- a/src/components/Code/__snapshots__/Code.test.js.snap
+++ b/src/components/Code/__snapshots__/Code.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Code /> should render correctly 1`] = `
+<Code__CodeWrapper
+  onClick={[Function]}
+>
+  <Code__Content>
+    <Code__Pre
+      innerRef={[Function]}
+    >
+      such code much programming
+    </Code__Pre>
+  </Code__Content>
+  <Code__CopyNotice>
+    <i
+      className="fa fa-check"
+    />
+     
+    Copy to clipboard
+  </Code__CopyNotice>
+</Code__CodeWrapper>
+`;

--- a/src/components/Code/example.js
+++ b/src/components/Code/example.js
@@ -1,0 +1,141 @@
+import React from 'react';
+import { trim } from 'lodash';
+import styled from 'styled-components';
+
+import { Example, Info } from '../../utils/example';
+import { Input } from '..';
+import Code from '.';
+
+const Highlight = styled.span`
+  color: ${props => props.theme.colors.blue400};
+`;
+
+export default class CodeExample extends React.Component {
+  state = {
+    value: '<ACCESS_KEY>',
+  };
+
+  onCopy = () => {
+    console.log('Copied');
+  };
+
+  onChange = e => {
+    this.setState({
+      value: e.target.value,
+    });
+  };
+
+  render() {
+    return (
+      <div>
+        <Input placeholder="Dynamic content" onChange={this.onChange} />
+
+        <Info>Long single line command</Info>
+        <Example>
+          <Code onCopy={this.onCopy}>
+            kubectl create secret generic -n weave cloudwatch
+            --from-literal=access-key-id=xyz
+            --from-literal=secret-access-key=abc
+          </Code>
+        </Example>
+
+        <Info>Multiline file</Info>
+        <Example>
+          <Code isFile onCopy={this.onCopy}>
+            {`
+{
+  "AccessKey": {
+    "AccessKeyId": "<YOUR_ACCESS_TOKEN>",
+    "SecretAccessKey": "<YOUR_SECRET_ACCESS_KEY>"
+  }
+}
+          `}
+          </Code>
+        </Example>
+
+        <Info>Multiline single command</Info>
+        <Example>
+          <Code onCopy={this.onCopy}>
+            {`
+kubectl create secret generic -n weave cloudwatch \\
+  --from-literal=access-key-id=xyz \\
+  --from-literal=secret-access-key=abc
+          `}
+          </Code>
+        </Example>
+
+        <Info>Dynamic content in template string</Info>
+        <Example>
+          <Code isFile onCopy={this.onCopy}>
+            {() =>
+              trim(`
+{
+  "AccessKey": {
+    "AccessKeyId": "${this.state.value}",
+    "SecretAccessKey": "<YOUR_SECRET_ACCESS_KEY>"
+  }
+}
+          `)
+            }
+          </Code>
+        </Example>
+
+        <Info>Dynamic content using template strings and JSX</Info>
+        <Example>
+          <Code onCopy={this.onCopy}>
+            <span>
+              {'kubectl create secret generic -n weave cloudwatch \\'}
+              {'\n  '}
+              <strong>--from-literal=access-key-id=</strong>
+              <Highlight>{this.state.value}</Highlight>
+              {' \\\n  '}
+              {'--from-literal=secret-access-key='}
+            </span>
+          </Code>
+        </Example>
+
+        <Info>Dynamic content using HTML</Info>
+        <Example>
+          <Code onCopy={this.onCopy}>
+            <div>
+              kubectl create secret generic -n weave cloudwatch \<br />
+              <span>
+                <strong>{'  '}--from-literal=access-key-id=</strong>
+                {this.state.value} \<br />
+              </span>
+              <span>{'  '}--from-literal=secret-access-key=</span>
+            </div>
+          </Code>
+        </Example>
+
+        <Info>Dynamic content using HTML</Info>
+        <Example>
+          <Code onCopy={this.onCopy}>
+            <div>
+              <div>{'{'}</div>
+              <div>
+                {'  '}&quot;AccessKey&quot;: {'{'}
+              </div>
+              <div>
+                {'    '}
+                <strong>&quot;AccessKeyId&quot;</strong>: &quot;{
+                  this.state.value
+                }&quot;,
+              </div>
+              <div>
+                {'    '}
+                <strong>&quot;SecretAccessKey&quot;</strong>:{' '}
+                {'"<YOUR_SECRET_ACCESS_KEY>"'}
+              </div>
+              <div>
+                {'  '}
+                {'}'}
+              </div>
+              <div>{'}'}</div>
+            </div>
+          </Code>
+        </Example>
+      </div>
+    );
+  }
+}

--- a/src/components/Code/index.js
+++ b/src/components/Code/index.js
@@ -1,0 +1,1 @@
+export default from './Code';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,7 @@
 export Button from './Button';
 
+export Code from './Code';
+
 export Grid, { GridColumn, GridRow } from './Grid';
 
 export Dialog from './Dialog';


### PR DESCRIPTION
I have tried to simplify the API and usage to be more intuitive although for more complex styled/dynamic setups there is still some jsx wrangling required.

Couple of things to discuss:
 - current implementation has the content scroll when it overflows. I think this is the sanest option, but visually will change across different OS/Browsers?
 - Do we want to shrink the copy button so it occupies less of the code space?


![image](https://user-images.githubusercontent.com/1794071/41597665-ffd3c340-73c5-11e8-8877-7676aa83e9b8.png)

![image](https://user-images.githubusercontent.com/1794071/41541524-962804da-730a-11e8-96af-ced2bcf2d35f.png)

![image](https://user-images.githubusercontent.com/1794071/41541559-a9c35b52-730a-11e8-9cd3-b631c2a52a51.png)



fixes #244 
