### PR TITLE
Add extraHeaders prop to DataTable

### DIFF
--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -175,7 +175,7 @@ class DataTable extends React.PureComponent {
   };
 
   render() {
-    const { className, children, columns, nested } = this.props;
+    const { className, children, columns, nested, extraHeaders } = this.props;
     const { sortedData, sortOrder, sortField } = this.state;
 
     return (
@@ -193,6 +193,7 @@ class DataTable extends React.PureComponent {
                 {label}
               </Header>
             ))}
+            {map(extraHeaders, (h, i) => <th key={i}>{h}</th>)}
           </tr>
         </thead>
         {/* Don't render the tbody if nested; nested tables use <tbody> for rows */}
@@ -243,6 +244,11 @@ DataTable.propTypes = {
    * All child rows of `nested` tables should be <tbody /> tags
    */
   nested: PropTypes.bool,
+  /**
+   * Extra elements that will be added to the table headers.
+   * These columns will NOT be sortable.
+   */
+  extraHeaders: PropTypes.arrayOf(PropTypes.element),
 };
 
 DataTable.defaultProps = {

--- a/src/components/DataTable/DataTable.test.js
+++ b/src/components/DataTable/DataTable.test.js
@@ -154,6 +154,30 @@ describe('DataTable', () => {
 
       expect(tree).toMatchSnapshot();
     });
+    it('renders extra headers', () => {
+      const tree = renderer
+        .create(
+          withTheme(
+            <DataTable
+              data={data}
+              columns={[{ value: 'name', label: 'Name' }, { value: 'email', label: 'Email' }]}
+              extraHeaders={[<div>Some other header</div>, <div>Another one</div>]}
+            >
+              {rows =>
+                map(rows, r => (
+                  <tr key={r.email}>
+                    <td>{r.name}</td>
+                    <td>{r.email}</td>
+                  </tr>
+                ))
+              }
+            </DataTable>
+          )
+        )
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
   });
   it('sorts on click', () => {
     const table = mount(

--- a/src/components/DataTable/__snapshots__/DataTable.test.js.snap
+++ b/src/components/DataTable/__snapshots__/DataTable.test.js.snap
@@ -1,5 +1,105 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DataTable snapshots renders extra headers 1`] = `
+.c1 {
+  text-align: left;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c1:hover {
+  color: #037aa9;
+}
+
+.c0 {
+  border-collapse: collapse;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.c0 td {
+  padding: 10px 8px;
+  vertical-align: top;
+  border-left: 1px solid rgba(223,223,234,0.4);
+}
+
+.c0 thead td {
+  border: 0;
+  font-weight: bold;
+}
+
+.c0 thead,
+.c0 tbody {
+  border-bottom: 1px solid rgba(223,223,234,0.4);
+  border-left: 3px solid transparent;
+}
+
+<table
+  className="c0"
+>
+  <thead>
+    <tr>
+      <td
+        className="c1"
+        onClick={[Function]}
+      >
+        Name
+         
+        <i
+          className="fa fa-caret-up"
+        />
+      </td>
+      <td
+        className="c1"
+        onClick={[Function]}
+      >
+        Email
+         
+      </td>
+      <th>
+        <div>
+          Some other header
+        </div>
+      </th>
+      <th>
+        <div>
+          Another one
+        </div>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        Albert
+      </td>
+      <td>
+        b@weave.works
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Bob
+      </td>
+      <td>
+        a@weave.works
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Ty
+      </td>
+      <td>
+        c@weave.works
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
 exports[`DataTable snapshots renders nested rows 1`] = `
 .c1 {
   text-align: left;

--- a/src/components/DataTable/example.js
+++ b/src/components/DataTable/example.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { map, max } from 'lodash';
 
 import { Example } from '../../utils/example';
+import Button from '../Button';
 
 import DataTable from '.';
 
@@ -76,6 +77,23 @@ export default function DataTableExample() {
                   </tr>
                 ))}
               </tbody>
+            ))
+          }
+        </DataTable>
+      </Example>
+      <Example>
+        <h3>With extra headers</h3>
+        <DataTable
+          data={data}
+          columns={[{ value: 'name', label: 'Name' }, { value: 'email', label: 'Email' }]}
+          extraHeaders={[<Button>Extra Header</Button>]}
+        >
+          {rows =>
+            map(rows, r => (
+              <tr key={r.email}>
+                <td>{r.name}</td>
+                <td>{r.email}</td>
+              </tr>
             ))
           }
         </DataTable>


### PR DESCRIPTION
Allows for arbitrary elements to be used as headers, ie Buttons, Dropdowns, etc.