### PR TITLE
Fix timeline dragging regression

### DIFF
--- a/src/components/TimeTravel/TimeTravel.js
+++ b/src/components/TimeTravel/TimeTravel.js
@@ -138,7 +138,7 @@ function initialDurationMsPerTimelinePx(earliestTimestamp) {
  * ```
  *
  */
-class TimeTravel extends React.Component {
+class TimeTravel extends React.PureComponent {
   constructor(props, context) {
     super(props, context);
 
@@ -173,14 +173,15 @@ class TimeTravel extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    const nextTimestamp = formattedTimestamp(nextProps.timestamp);
+
     // If live mode is supported and we're in it, ignore the timestamp prop and jump
-    // directly to the present timestamp, otherwise jump to the given timestamp prop.
+    // directly to the present timestamp, otherwise jump to the given timestamp prop
+    // if it has changed (to prevent regressions).
     if (nextProps.hasLiveMode && nextProps.showingLive) {
       this.setState({ focusedTimestamp: this.state.timestampNow });
-    } else {
-      this.setState({
-        focusedTimestamp: formattedTimestamp(nextProps.timestamp),
-      });
+    } else if (nextTimestamp !== this.props.timestamp) {
+      this.setState({ focusedTimestamp: nextTimestamp });
     }
     // Update live mode only if live mode toggle is enabled.
     if (nextProps.hasLiveMode) {

--- a/src/components/TimeTravel/_Timeline.js
+++ b/src/components/TimeTravel/_Timeline.js
@@ -80,7 +80,8 @@ const FullyPannableCanvas = styled.div`
 
 const TimelineContainer = FullyPannableCanvas.extend`
   background-color: ${props => transparentize(0.15, props.theme.colors.white)};
-  box-shadow: inset 0 0 7px ${props => transparentize(0.35, props.theme.colors.doveGray)};
+  box-shadow: inset 0 0 7px
+    ${props => transparentize(0.35, props.theme.colors.doveGray)};
   pointer-events: all;
   position: relative;
   height: 100%;

--- a/src/components/TimeTravel/example.js
+++ b/src/components/TimeTravel/example.js
@@ -24,26 +24,37 @@ export default class TimeTravelExample extends React.Component {
     super(props);
 
     this.state = {
-      timestamp1: moment().format(),
-      timestamp2: moment().format(),
-      timestamp3: moment().format(),
+      timestamp1: moment()
+        .utc()
+        .format(),
+      timestamp2: moment()
+        .utc()
+        .format(),
+      timestamp3: moment()
+        .utc()
+        .format(),
       isLoading2: false,
       showingLive3: true,
       rangeMs3: 3600000,
       visibleStartAt: null,
       visibleEndAt: null,
-      deployments: generateDeployments({
-        startTime: moment().subtract(1, 'month').unix(),
-        endTime: moment().unix(),
-      }, 500),
+      deployments: generateDeployments(
+        {
+          startTime: moment()
+            .subtract(1, 'month')
+            .unix(),
+          endTime: moment().unix(),
+        },
+        500
+      ),
     };
   }
 
-  handleChangeTimestamp1 = (timestamp1) => {
+  handleChangeTimestamp1 = timestamp1 => {
     this.setState({ timestamp1 });
   };
 
-  handleChangeTimestamp2 = (timestamp2) => {
+  handleChangeTimestamp2 = timestamp2 => {
     this.setState({ timestamp2, isLoading2: true });
     // Show loading indicator for 5 seconds after every timestamp change..
     setTimeout(() => {
@@ -51,15 +62,15 @@ export default class TimeTravelExample extends React.Component {
     }, 5000);
   };
 
-  handleChangeTimestamp3 = (timestamp3) => {
+  handleChangeTimestamp3 = timestamp3 => {
     this.setState({ timestamp3 });
   };
 
-  handleChangeLiveMode3 = (showingLive3) => {
+  handleChangeLiveMode3 = showingLive3 => {
     this.setState({ showingLive3 });
   };
 
-  handleChangeRange3 = (rangeMs3) => {
+  handleChangeRange3 = rangeMs3 => {
     this.setState({ rangeMs3 });
   };
 
@@ -68,7 +79,7 @@ export default class TimeTravelExample extends React.Component {
       visibleStartAt: startAt,
       visibleEndAt: endAt,
     });
-  }
+  };
 
   render() {
     return (


### PR DESCRIPTION
Fixes https://github.com/weaveworks/service-ui/issues/2677.

The timeline was bouncing back because it would sometimes get rerendered due to the parent component state change caused by `onUpdateVisibleRange` callback. The rerendering would happen before the `onChangeTimestamp` callback would update the timestamp, so the old timestamp would still be passed (and taken for the new `focusedTimestamp`).

This was fixed by updating the `focusedTimestamp` from props only if `timestamp` prop really changes, i.e. `nextTimestamp !== this.props.timestamp`.

##### Other Changes

* Made `TimeTravel` component a `PureComponent` for additional shallow props comparison, just in case
* Switched the example initial timestamps to UTC format, for greater compatibility
* Some cosmetic code changes caused by `prettier`
