### PR TITLE
Remove 3 redundant theme colors

### DIFF
--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -21,15 +21,12 @@ export const colors = {
   blue400: 'hsl(191, 100%, 50%)', // #00d2ff
   blue50: 'hsl(191, 100%, 97%)', // #f0fcff
 
-  // Uncategorized Colors
+  // Neutral Colors
   black: '#1a1a1a',
   doveGray: '#737373',
-  eastBay: '#4a5d87',
   gallery: '#f4f4f4',
-  mystic: '#dae4ea',
   silver: '#ccc',
   white: '#fff',
-  whiteLilac: '#f0f0fa',
 
   // Use these when colorizing elements that should indicate a state or outcome, ie Alerts.
   status: {

--- a/styleguide/Colors.js
+++ b/styleguide/Colors.js
@@ -171,7 +171,7 @@ class Colors extends React.Component {
         </Text>
         <Row>{this.renderSwatches(theme.colors.status)}</Row>
         <Text large bold>
-          Uncategorized Colors
+          Neutral Colors
         </Text>
         <Row>{this.renderSwatches(theme.colors, /^[^0-9]+$/)}</Row>
         <Separator />


### PR DESCRIPTION
![](https://placehold.it/15/4a5d87/000000?text=+) _eastBay_ - #264
![](https://placehold.it/15/dae4ea/000000?text=+) _mystic_ - #266 
![](https://placehold.it/15/f0f0fa/000000?text=+) _whiteLilac_ - #267

Now the only "uncategorized" colors are neutral colors so I renamed the category:

![image](https://user-images.githubusercontent.com/1216874/41598863-ca39843e-73d1-11e8-8d60-1c554579255e.png)

