### PR TITLE
add multiCommand prop to Code

### DIFF
--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -65,7 +65,56 @@ const Pre = styled.pre`
   font-size: ${props => props.theme.fontSizes.small};
 `;
 
+const PaddedLine = styled.div`
+  &:not(:last-child) {
+    padding-bottom: 8px;
+  }
+
+  /* required to make jsx children work with adding '\n' in multiLine */
+  & > div {
+    display: inline;
+  }
+`;
+
 const trimString = node => (isString(node) ? trim(node) : node);
+
+const formatSingleCommand = children =>
+  isFunction(children) ? children() : trimString(children);
+
+function formatMultiString(string) {
+  return trim(string)
+    .split('\n')
+    .map((line, i) => (
+      <PaddedLine key={i}>
+        {line}
+        {'\n'}
+      </PaddedLine>
+    ));
+}
+
+function formatMultiCommand(raw) {
+  let children = raw;
+
+  if (isFunction(children)) {
+    children = children();
+  }
+  const count = React.Children.count(children);
+
+  if (count === 1 && isString(children)) {
+    return formatMultiString(children);
+  }
+
+  if (count === 1) {
+    return children;
+  }
+
+  return React.Children.map(children, (child, i) => (
+    <PaddedLine key={i}>
+      {child}
+      {'\n'}
+    </PaddedLine>
+  ));
+}
 
 /**
  * Code allows for easy rendering of code snippets which can easliy be copied to
@@ -151,7 +200,7 @@ class Code extends Component {
   };
 
   render() {
-    const { children } = this.props;
+    const { children, multiCommand } = this.props;
     const { isCopying, isHovered } = this.state;
 
     const copy =
@@ -170,7 +219,9 @@ class Code extends Component {
         <ScrollWrap>
           <Content>
             <Pre innerRef={e => (this.preNode = e)}>
-              {isFunction(children) ? children() : trimString(children)}
+              {multiCommand
+                ? formatMultiCommand(children)
+                : formatSingleCommand(children)}
             </Pre>
           </Content>
         </ScrollWrap>
@@ -184,14 +235,18 @@ class Code extends Component {
 }
 
 Code.propTypes = {
-  // Children can be anything that React can render
+  // children can be anything that React can render
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+
+  // multiCommand determines if the code lines shall be padded
+  multiCommand: PropTypes.bool,
 
   // onCopy will be called when the CodeWrapper is clicked
   onCopy: PropTypes.func,
 };
 
 Code.defaultProps = {
+  multiCommand: false,
   onCopy: noop,
 };
 

--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -71,7 +71,7 @@ const PaddedLine = styled.div`
   }
 
   /* required to make jsx children work with adding '\n' in multiLine */
-  & > div {
+  & > * {
     display: inline;
   }
 `;
@@ -84,8 +84,8 @@ const formatSingleCommand = children =>
 function formatMultiString(string) {
   return trim(string)
     .split('\n')
-    .map((line, i) => (
-      <PaddedLine key={i}>
+    .map(line => (
+      <PaddedLine key={line}>
         {line}
         {'\n'}
       </PaddedLine>
@@ -100,12 +100,8 @@ function formatMultiCommand(raw) {
   }
   const count = React.Children.count(children);
 
-  if (count === 1 && isString(children)) {
-    return formatMultiString(children);
-  }
-
   if (count === 1) {
-    return children;
+    return isString(children) ? formatMultiString(children) : children;
   }
 
   return React.Children.map(children, (child, i) => (
@@ -156,7 +152,7 @@ class Code extends Component {
         selectedRange: selection.getRangeAt(0),
       });
     }
-    // console.dir(document.getSelection().anchorNode);
+
     const code =
       selectionString === '' ? this.preNode.textContent : selectionString;
     const txtArea = document.createElement('textarea');

--- a/src/components/Code/Code.test.js
+++ b/src/components/Code/Code.test.js
@@ -38,4 +38,48 @@ describe('<Code />', () => {
   it('should render correctly', () => {
     expect(wrapper.dive()).toMatchSnapshot();
   });
+
+  it('should render multi line string correctly with multiCommand=true', () => {
+    wrapper = shallow(
+      withTheme(
+        <Code multiCommand>{`
+sudo curl -l git.io/scope -o /usr/local/bin/scope
+sudo chmod a+x /usr/local/bin/scope
+scope launch https://yjsjsubdx1h8un1f858gp7to8d51zdre@frontend.dev.weave.works
+      `}</Code>
+      )
+    );
+    expect(wrapper.dive()).toMatchSnapshot();
+  });
+
+  it('should render multi line function correctly with multiCommand=true', () => {
+    wrapper = shallow(
+      withTheme(
+        <Code multiCommand>
+          {() => `
+sudo curl -l git.io/scope -o /usr/local/bin/scope
+sudo chmod a+x /usr/local/bin/scope
+scope launch https://yjsjsubdx1h8un1f858gp7to8d51zdre@frontend.dev.weave.works
+      `}
+        </Code>
+      )
+    );
+    expect(wrapper.dive()).toMatchSnapshot();
+  });
+
+  it('should render multi line jsx correctly with multiCommand=true', () => {
+    wrapper = shallow(
+      withTheme(
+        <Code multiCommand>
+          <div>sudo curl -L git.io/scope -o /usr/local/bin/scope</div>
+          <div>sudo chmod a+x /usr/local/bin/scope</div>
+          <div>
+            scope launch <wbr />
+            https://yjsjsubdx1h8un1f858gp7to8d51zdre@frontend.dev.weave.works
+          </div>
+        </Code>
+      )
+    );
+    expect(wrapper.dive()).toMatchSnapshot();
+  });
 });

--- a/src/components/Code/__snapshots__/Code.test.js.snap
+++ b/src/components/Code/__snapshots__/Code.test.js.snap
@@ -23,3 +23,134 @@ exports[`<Code /> should render correctly 1`] = `
   </Code__CopyNotice>
 </Code__CodeWrapper>
 `;
+
+exports[`<Code /> should render multi line function correctly with multiCommand=true 1`] = `
+<Code__CodeWrapper
+  onClick={[Function]}
+>
+  <Code__Content>
+    <Code__Pre
+      innerRef={[Function]}
+    >
+      <Code__PaddedLine
+        key="0"
+      >
+        sudo curl -l git.io/scope -o /usr/local/bin/scope
+        
+        
+      </Code__PaddedLine>
+      <Code__PaddedLine
+        key="1"
+      >
+        sudo chmod a+x /usr/local/bin/scope
+        
+        
+      </Code__PaddedLine>
+      <Code__PaddedLine
+        key="2"
+      >
+        scope launch https://yjsjsubdx1h8un1f858gp7to8d51zdre@frontend.dev.weave.works
+        
+        
+      </Code__PaddedLine>
+    </Code__Pre>
+  </Code__Content>
+  <Code__CopyNotice>
+    <i
+      className="fa fa-check"
+    />
+     
+    Copy to clipboard
+  </Code__CopyNotice>
+</Code__CodeWrapper>
+`;
+
+exports[`<Code /> should render multi line jsx correctly with multiCommand=true 1`] = `
+<Code__CodeWrapper
+  onClick={[Function]}
+>
+  <Code__Content>
+    <Code__Pre
+      innerRef={[Function]}
+    >
+      <Code__PaddedLine
+        key="0/.0"
+      >
+        <div>
+          sudo curl -L git.io/scope -o /usr/local/bin/scope
+        </div>
+        
+        
+      </Code__PaddedLine>
+      <Code__PaddedLine
+        key="1/.1"
+      >
+        <div>
+          sudo chmod a+x /usr/local/bin/scope
+        </div>
+        
+        
+      </Code__PaddedLine>
+      <Code__PaddedLine
+        key="2/.2"
+      >
+        <div>
+          scope launch 
+          <wbr />
+          https://yjsjsubdx1h8un1f858gp7to8d51zdre@frontend.dev.weave.works
+        </div>
+        
+        
+      </Code__PaddedLine>
+    </Code__Pre>
+  </Code__Content>
+  <Code__CopyNotice>
+    <i
+      className="fa fa-check"
+    />
+     
+    Copy to clipboard
+  </Code__CopyNotice>
+</Code__CodeWrapper>
+`;
+
+exports[`<Code /> should render multi line string correctly with multiCommand=true 1`] = `
+<Code__CodeWrapper
+  onClick={[Function]}
+>
+  <Code__Content>
+    <Code__Pre
+      innerRef={[Function]}
+    >
+      <Code__PaddedLine
+        key="0"
+      >
+        sudo curl -l git.io/scope -o /usr/local/bin/scope
+        
+        
+      </Code__PaddedLine>
+      <Code__PaddedLine
+        key="1"
+      >
+        sudo chmod a+x /usr/local/bin/scope
+        
+        
+      </Code__PaddedLine>
+      <Code__PaddedLine
+        key="2"
+      >
+        scope launch https://yjsjsubdx1h8un1f858gp7to8d51zdre@frontend.dev.weave.works
+        
+        
+      </Code__PaddedLine>
+    </Code__Pre>
+  </Code__Content>
+  <Code__CopyNotice>
+    <i
+      className="fa fa-check"
+    />
+     
+    Copy to clipboard
+  </Code__CopyNotice>
+</Code__CodeWrapper>
+`;

--- a/src/components/Code/__snapshots__/Code.test.js.snap
+++ b/src/components/Code/__snapshots__/Code.test.js.snap
@@ -27,39 +27,42 @@ exports[`<Code /> should render correctly 1`] = `
 exports[`<Code /> should render multi line function correctly with multiCommand=true 1`] = `
 <Code__CodeWrapper
   onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
-  <Code__Content>
-    <Code__Pre
-      innerRef={[Function]}
-    >
-      <Code__PaddedLine
-        key="0"
+  <Code__ScrollWrap>
+    <Code__Content>
+      <Code__Pre
+        innerRef={[Function]}
       >
-        sudo curl -l git.io/scope -o /usr/local/bin/scope
-        
-        
-      </Code__PaddedLine>
-      <Code__PaddedLine
-        key="1"
-      >
-        sudo chmod a+x /usr/local/bin/scope
-        
-        
-      </Code__PaddedLine>
-      <Code__PaddedLine
-        key="2"
-      >
-        scope launch https://yjsjsubdx1h8un1f858gp7to8d51zdre@frontend.dev.weave.works
-        
-        
-      </Code__PaddedLine>
-    </Code__Pre>
-  </Code__Content>
-  <Code__CopyNotice>
-    <i
-      className="fa fa-check"
-    />
-     
+        <Code__PaddedLine
+          key="sudo curl -l git.io/scope -o /usr/local/bin/scope"
+        >
+          sudo curl -l git.io/scope -o /usr/local/bin/scope
+          
+          
+        </Code__PaddedLine>
+        <Code__PaddedLine
+          key="sudo chmod a+x /usr/local/bin/scope"
+        >
+          sudo chmod a+x /usr/local/bin/scope
+          
+          
+        </Code__PaddedLine>
+        <Code__PaddedLine
+          key="scope launch https://yjsjsubdx1h8un1f858gp7to8d51zdre@frontend.dev.weave.works"
+        >
+          scope launch https://yjsjsubdx1h8un1f858gp7to8d51zdre@frontend.dev.weave.works
+          
+          
+        </Code__PaddedLine>
+      </Code__Pre>
+    </Code__Content>
+  </Code__ScrollWrap>
+  <Code__CopyNotice
+    isCopying={false}
+    isHovered={false}
+  >
     Copy to clipboard
   </Code__CopyNotice>
 </Code__CodeWrapper>
@@ -68,47 +71,50 @@ exports[`<Code /> should render multi line function correctly with multiCommand=
 exports[`<Code /> should render multi line jsx correctly with multiCommand=true 1`] = `
 <Code__CodeWrapper
   onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
-  <Code__Content>
-    <Code__Pre
-      innerRef={[Function]}
-    >
-      <Code__PaddedLine
-        key="0/.0"
+  <Code__ScrollWrap>
+    <Code__Content>
+      <Code__Pre
+        innerRef={[Function]}
       >
-        <div>
-          sudo curl -L git.io/scope -o /usr/local/bin/scope
-        </div>
-        
-        
-      </Code__PaddedLine>
-      <Code__PaddedLine
-        key="1/.1"
-      >
-        <div>
-          sudo chmod a+x /usr/local/bin/scope
-        </div>
-        
-        
-      </Code__PaddedLine>
-      <Code__PaddedLine
-        key="2/.2"
-      >
-        <div>
-          scope launch 
-          <wbr />
-          https://yjsjsubdx1h8un1f858gp7to8d51zdre@frontend.dev.weave.works
-        </div>
-        
-        
-      </Code__PaddedLine>
-    </Code__Pre>
-  </Code__Content>
-  <Code__CopyNotice>
-    <i
-      className="fa fa-check"
-    />
-     
+        <Code__PaddedLine
+          key="0/.0"
+        >
+          <div>
+            sudo curl -L git.io/scope -o /usr/local/bin/scope
+          </div>
+          
+          
+        </Code__PaddedLine>
+        <Code__PaddedLine
+          key="1/.1"
+        >
+          <div>
+            sudo chmod a+x /usr/local/bin/scope
+          </div>
+          
+          
+        </Code__PaddedLine>
+        <Code__PaddedLine
+          key="2/.2"
+        >
+          <div>
+            scope launch 
+            <wbr />
+            https://yjsjsubdx1h8un1f858gp7to8d51zdre@frontend.dev.weave.works
+          </div>
+          
+          
+        </Code__PaddedLine>
+      </Code__Pre>
+    </Code__Content>
+  </Code__ScrollWrap>
+  <Code__CopyNotice
+    isCopying={false}
+    isHovered={false}
+  >
     Copy to clipboard
   </Code__CopyNotice>
 </Code__CodeWrapper>
@@ -117,39 +123,42 @@ exports[`<Code /> should render multi line jsx correctly with multiCommand=true 
 exports[`<Code /> should render multi line string correctly with multiCommand=true 1`] = `
 <Code__CodeWrapper
   onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
-  <Code__Content>
-    <Code__Pre
-      innerRef={[Function]}
-    >
-      <Code__PaddedLine
-        key="0"
+  <Code__ScrollWrap>
+    <Code__Content>
+      <Code__Pre
+        innerRef={[Function]}
       >
-        sudo curl -l git.io/scope -o /usr/local/bin/scope
-        
-        
-      </Code__PaddedLine>
-      <Code__PaddedLine
-        key="1"
-      >
-        sudo chmod a+x /usr/local/bin/scope
-        
-        
-      </Code__PaddedLine>
-      <Code__PaddedLine
-        key="2"
-      >
-        scope launch https://yjsjsubdx1h8un1f858gp7to8d51zdre@frontend.dev.weave.works
-        
-        
-      </Code__PaddedLine>
-    </Code__Pre>
-  </Code__Content>
-  <Code__CopyNotice>
-    <i
-      className="fa fa-check"
-    />
-     
+        <Code__PaddedLine
+          key="sudo curl -l git.io/scope -o /usr/local/bin/scope"
+        >
+          sudo curl -l git.io/scope -o /usr/local/bin/scope
+          
+          
+        </Code__PaddedLine>
+        <Code__PaddedLine
+          key="sudo chmod a+x /usr/local/bin/scope"
+        >
+          sudo chmod a+x /usr/local/bin/scope
+          
+          
+        </Code__PaddedLine>
+        <Code__PaddedLine
+          key="scope launch https://yjsjsubdx1h8un1f858gp7to8d51zdre@frontend.dev.weave.works"
+        >
+          scope launch https://yjsjsubdx1h8un1f858gp7to8d51zdre@frontend.dev.weave.works
+          
+          
+        </Code__PaddedLine>
+      </Code__Pre>
+    </Code__Content>
+  </Code__ScrollWrap>
+  <Code__CopyNotice
+    isCopying={false}
+    isHovered={false}
+  >
     Copy to clipboard
   </Code__CopyNotice>
 </Code__CodeWrapper>

--- a/src/components/Code/example.js
+++ b/src/components/Code/example.js
@@ -64,6 +64,40 @@ kubectl create secret generic -n weave cloudwatch \\
           </Code>
         </Example>
 
+        <Info>Multiline multi command string</Info>
+        <Example>
+          <Code onCopy={this.onCopy} multiCommand>
+            {`
+sudo curl -L git.io/scope -o /usr/local/bin/scope
+sudo chmod a+x /usr/local/bin/scope
+scope launch https://yjsjsubdx1h8un1f858gp7to8d51zdre@frontend.dev.weave.works
+          `}
+          </Code>
+        </Example>
+
+        <Info>Multiline multi command JSX</Info>
+        <Example>
+          <Code onCopy={this.onCopy} multiCommand>
+            <div>sudo curl -L git.io/scope -o /usr/local/bin/scope</div>
+            <div>sudo chmod a+x /usr/local/bin/scope</div>
+            <div>
+              scope launch <wbr />
+              https://yjsjsubdx1h8un1f858gp7to8d51zdre@frontend.dev.weave.works
+            </div>
+          </Code>
+        </Example>
+
+        <Info>Multiline multi command function</Info>
+        <Example>
+          <Code onCopy={this.onCopy} multiCommand>
+            {() => `
+sudo curl -L git.io/scope -o /usr/local/bin/scope
+sudo chmod a+x /usr/local/bin/scope
+scope launch https://${this.state.value}
+          `}
+          </Code>
+        </Example>
+
         <Info>Dynamic content in template string</Info>
         <Example>
           <Code isFile onCopy={this.onCopy}>


### PR DESCRIPTION
visual differentiation between single command split across multiple
lines and multiple commands to be run in sequence

fixes #278 
![image](https://user-images.githubusercontent.com/1794071/41775635-9c0e88fa-761c-11e8-9c4f-3fb157cfcbfc.png)


Have added three new examples for the multiCommand variations, not sure if they are really needed, would probably be fine with one additional example? @fbarl thoughts?