### PR TITLE
add small option for TabSelect

### DIFF
--- a/src/components/TabSelect/TabSelect.js
+++ b/src/components/TabSelect/TabSelect.js
@@ -20,7 +20,7 @@ const bordersOnlyTop = props => `
 `;
 
 const TabContent = styled.div`
-  padding: 20px;
+  padding: ${props => (props.small ? '10px' : '20px')};
   background-color: ${props =>
     props.secondary ? 'transparent' : props.theme.colors.white};
 
@@ -55,7 +55,7 @@ class TabSelect extends React.PureComponent {
   };
 
   render() {
-    const { className, children, secondary } = this.props;
+    const { className, children, secondary, small } = this.props;
     const tabs = React.Children.map(children, child =>
       pick(child.props, ['label', 'name'])
     );
@@ -71,13 +71,16 @@ class TabSelect extends React.PureComponent {
               name={tab.name}
               selected={this.isSelectedTab(tab)}
               secondary={secondary}
+              small={small}
               onClick={this.handleTabClick}
             >
               {tab.label}
             </TabButton>
           ))}
         </TabButtons>
-        <TabContent secondary={secondary}>{selected}</TabContent>
+        <TabContent small={small} secondary={secondary}>
+          {selected}
+        </TabContent>
       </div>
     );
   }
@@ -89,6 +92,10 @@ TabSelect.propTypes = {
    * transparent background
    */
   secondary: PropTypes.bool,
+  /**
+   * Small styling for TabSelect
+   */
+  small: PropTypes.bool,
   /**
    * The tab to show on first render.
    * Supplying a new value to this prop will override the currently selected item
@@ -114,6 +121,7 @@ TabSelect.propTypes = {
 
 TabSelect.defaultProps = {
   secondary: false,
+  small: false,
 };
 
 export default Styled(TabSelect);

--- a/src/components/TabSelect/_TabButton.js
+++ b/src/components/TabSelect/_TabButton.js
@@ -15,8 +15,9 @@ const Styled = component => styled(component)`
   cursor: pointer;
   margin-bottom: -1px;
   margin-right: 5px;
-  padding: 10px 20px;
-  font-size: ${props => props.theme.fontSizes.large};
+  padding: ${props => (props.small ? '5px 10px' : '10px 20px')};
+  font-size: ${props =>
+    props.small ? props.theme.fontSizes.normal : props.theme.fontSizes.large};
   outline: 0;
 
   ${({ selected, secondary, theme }) => `

--- a/src/components/TabSelect/example.js
+++ b/src/components/TabSelect/example.js
@@ -35,6 +35,20 @@ export default function TabSelectExample() {
           </Tab>
         </TabSelect>
       </Example>
+      <Info>Small</Info>
+      <Example>
+        <TabSelect small>
+          <Tab label="A" name="a">
+            Tab A
+          </Tab>
+          <Tab label="B" name="b">
+            Tab B
+          </Tab>
+          <Tab label="C" name="c">
+            Tab C
+          </Tab>
+        </TabSelect>
+      </Example>
     </div>
   );
 }


### PR DESCRIPTION
used for code snippets in k8s onboarding, used for more inline tabs within
other page content

![image](https://user-images.githubusercontent.com/1794071/41987063-0c7469ae-7a30-11e8-9cad-0c9385c40dcf.png)
