### PR TITLE
Add width and element fields to DataTable header

### DIFF
--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -182,15 +182,16 @@ class DataTable extends React.PureComponent {
       <table className={className}>
         <thead>
           <tr>
-            {map(columns, ({ value, label, sortable }) => (
+            {map(columns, ({ value, label, sortable, width, element }) => (
               <Header
                 sortable={sortable}
                 order={sortField === value ? sortOrder : null}
                 value={value}
                 onClick={this.handleHeaderClick}
                 key={value}
+                width={width}
               >
-                {label}
+                {element || label}
               </Header>
             ))}
             {map(extraHeaders, (h, i) => <th key={i}>{h}</th>)}
@@ -206,6 +207,9 @@ class DataTable extends React.PureComponent {
 const columnPropType = PropTypes.shape({
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   label: PropTypes.string,
+  sortable: PropTypes.bool,
+  width: PropTypes.string,
+  element: PropTypes.element,
 });
 
 DataTable.propTypes = {
@@ -221,6 +225,7 @@ DataTable.propTypes = {
   /**
    * An array of objects that will be used as columns.
    * `value` must map to a key in your data in order for sorting to work.
+   * If an `element` key is specified, that element will be used instead of `label`.
    */
   columns: PropTypes.arrayOf(columnPropType).isRequired,
   /**

--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -190,6 +190,7 @@ class DataTable extends React.PureComponent {
                 onClick={this.handleHeaderClick}
                 key={value}
                 width={width}
+                title={label}
               >
                 {element || label}
               </Header>

--- a/src/components/DataTable/DataTable.test.js
+++ b/src/components/DataTable/DataTable.test.js
@@ -178,6 +178,58 @@ describe('DataTable', () => {
 
       expect(tree).toMatchSnapshot();
     });
+    it('renders an element instead of a label', () => {
+      const tree = renderer
+        .create(
+          withTheme(
+            <DataTable
+              data={data}
+              columns={[
+                { value: 'name', element: <i className="fa fa-some-icon" /> },
+                { value: 'email', label: 'Email' },
+              ]}
+            >
+              {rows =>
+                map(rows, r => (
+                  <tr key={r.email}>
+                    <td>{r.name}</td>
+                    <td>{r.email}</td>
+                  </tr>
+                ))
+              }
+            </DataTable>
+          )
+        )
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+    it('renders column widths', () => {
+      const tree = renderer
+        .create(
+          withTheme(
+            <DataTable
+              data={data}
+              columns={[
+                { value: 'name', label: 'Name', width: '20px' },
+                { value: 'email', label: 'Email', width: '80px' },
+              ]}
+            >
+              {rows =>
+                map(rows, r => (
+                  <tr key={r.email}>
+                    <td>{r.name}</td>
+                    <td>{r.email}</td>
+                  </tr>
+                ))
+              }
+            </DataTable>
+          )
+        )
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
   });
   it('sorts on click', () => {
     const table = mount(

--- a/src/components/DataTable/_Header.js
+++ b/src/components/DataTable/_Header.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
+import PropTypes from 'prop-types';
 
 const StyledHeader = component => styled(component)`
   text-align: left;
   cursor: ${props => (props.sortable ? 'pointer' : 'inherit')};
   user-select: none;
+  width: ${props => props.width};
 
   &:hover {
     color: ${props => (props.sortable ? props.theme.colors.blue700 : 'inherit')};
@@ -21,12 +23,13 @@ class Header extends React.Component {
   };
 
   render() {
-    const { className, children, order } = this.props;
+    const { className, children, order, sortable } = this.props;
 
     return (
       <td onClick={this.handleClick} className={className}>
         {children}{' '}
-        {order && <i className={order === 'asc' ? 'fa fa-caret-up' : 'fa fa-caret-down'} />}
+        {order &&
+          sortable && <i className={order === 'asc' ? 'fa fa-caret-up' : 'fa fa-caret-down'} />}
       </td>
     );
   }
@@ -34,6 +37,21 @@ class Header extends React.Component {
 
 // Only way to declare default props :(
 const Styled = StyledHeader(Header);
+
+Styled.propTypes = {
+  /**
+   * Whether or not the column will be sortable
+   */
+  sortable: PropTypes.bool,
+  /**
+   * The width that will be applied to the column
+   */
+  width: PropTypes.string,
+  /**
+   * Sort order. Should be either `asc` or `desc`
+   */
+  order: PropTypes.oneOf(['asc', 'desc']),
+};
 
 Styled.defaultProps = {
   sortable: true,

--- a/src/components/DataTable/_Header.js
+++ b/src/components/DataTable/_Header.js
@@ -9,7 +9,8 @@ const StyledHeader = component => styled(component)`
   width: ${props => props.width};
 
   &:hover {
-    color: ${props => (props.sortable ? props.theme.colors.blue700 : 'inherit')};
+    color: ${props =>
+      props.sortable ? props.theme.colors.blue700 : 'inherit'};
   }
 `;
 
@@ -23,13 +24,19 @@ class Header extends React.Component {
   };
 
   render() {
-    const { className, children, order, sortable } = this.props;
+    const { className, children, order, sortable, title } = this.props;
 
     return (
-      <td onClick={this.handleClick} className={className}>
+      <td onClick={this.handleClick} className={className} title={title}>
         {children}{' '}
         {order &&
-          sortable && <i className={order === 'asc' ? 'fa fa-caret-up' : 'fa fa-caret-down'} />}
+          sortable && (
+            <i
+              className={
+                order === 'asc' ? 'fa fa-caret-up' : 'fa fa-caret-down'
+              }
+            />
+          )}
       </td>
     );
   }

--- a/src/components/DataTable/__snapshots__/DataTable.test.js.snap
+++ b/src/components/DataTable/__snapshots__/DataTable.test.js.snap
@@ -45,6 +45,7 @@ exports[`DataTable snapshots renders an element instead of a label 1`] = `
       <td
         className="c1"
         onClick={[Function]}
+        title={undefined}
       >
         <i
           className="fa fa-some-icon"
@@ -57,6 +58,7 @@ exports[`DataTable snapshots renders an element instead of a label 1`] = `
       <td
         className="c1"
         onClick={[Function]}
+        title="Email"
       >
         Email
          
@@ -152,6 +154,7 @@ exports[`DataTable snapshots renders column widths 1`] = `
       <td
         className="c1"
         onClick={[Function]}
+        title="Name"
       >
         Name
          
@@ -162,6 +165,7 @@ exports[`DataTable snapshots renders column widths 1`] = `
       <td
         className="c2"
         onClick={[Function]}
+        title="Email"
       >
         Email
          
@@ -242,6 +246,7 @@ exports[`DataTable snapshots renders extra headers 1`] = `
       <td
         className="c1"
         onClick={[Function]}
+        title="Name"
       >
         Name
          
@@ -252,6 +257,7 @@ exports[`DataTable snapshots renders extra headers 1`] = `
       <td
         className="c1"
         onClick={[Function]}
+        title="Email"
       >
         Email
          
@@ -342,6 +348,7 @@ exports[`DataTable snapshots renders nested rows 1`] = `
       <td
         className="c1"
         onClick={[Function]}
+        title="Workload"
       >
         Workload
          
@@ -352,6 +359,7 @@ exports[`DataTable snapshots renders nested rows 1`] = `
       <td
         className="c1"
         onClick={[Function]}
+        title="Containers"
       >
         Containers
          
@@ -359,6 +367,7 @@ exports[`DataTable snapshots renders nested rows 1`] = `
       <td
         className="c1"
         onClick={[Function]}
+        title="Behind"
       >
         Behind
          
@@ -461,6 +470,7 @@ exports[`DataTable snapshots renders rows 1`] = `
       <td
         className="c1"
         onClick={[Function]}
+        title="Name"
       >
         Name
          
@@ -471,6 +481,7 @@ exports[`DataTable snapshots renders rows 1`] = `
       <td
         className="c1"
         onClick={[Function]}
+        title="Email"
       >
         Email
          
@@ -551,6 +562,7 @@ exports[`DataTable snapshots sorts fields by a give order 1`] = `
       <td
         className="c1"
         onClick={[Function]}
+        title="Name"
       >
         Name
          
@@ -558,6 +570,7 @@ exports[`DataTable snapshots sorts fields by a give order 1`] = `
       <td
         className="c1"
         onClick={[Function]}
+        title="Email"
       >
         Email
          
@@ -641,6 +654,7 @@ exports[`DataTable snapshots sorts rows by a field 1`] = `
       <td
         className="c1"
         onClick={[Function]}
+        title="Name"
       >
         Name
          
@@ -648,6 +662,7 @@ exports[`DataTable snapshots sorts rows by a field 1`] = `
       <td
         className="c1"
         onClick={[Function]}
+        title="Email"
       >
         Email
          

--- a/src/components/DataTable/__snapshots__/DataTable.test.js.snap
+++ b/src/components/DataTable/__snapshots__/DataTable.test.js.snap
@@ -1,5 +1,202 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DataTable snapshots renders an element instead of a label 1`] = `
+.c1 {
+  text-align: left;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c1:hover {
+  color: hsl(191,100%,35%);
+}
+
+.c0 {
+  border-collapse: collapse;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.c0 td {
+  padding: 10px 8px;
+  vertical-align: top;
+  border-left: 1px solid rgba(224,224,235,0.4);
+}
+
+.c0 thead td {
+  border: 0;
+  font-weight: bold;
+}
+
+.c0 thead,
+.c0 tbody {
+  border-bottom: 1px solid rgba(224,224,235,0.4);
+  border-left: 3px solid transparent;
+}
+
+<table
+  className="c0"
+>
+  <thead>
+    <tr>
+      <td
+        className="c1"
+        onClick={[Function]}
+      >
+        <i
+          className="fa fa-some-icon"
+        />
+         
+        <i
+          className="fa fa-caret-up"
+        />
+      </td>
+      <td
+        className="c1"
+        onClick={[Function]}
+      >
+        Email
+         
+      </td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        Albert
+      </td>
+      <td>
+        b@weave.works
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Bob
+      </td>
+      <td>
+        a@weave.works
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Ty
+      </td>
+      <td>
+        c@weave.works
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`DataTable snapshots renders column widths 1`] = `
+.c1 {
+  text-align: left;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 20px;
+}
+
+.c1:hover {
+  color: hsl(191,100%,35%);
+}
+
+.c2 {
+  text-align: left;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 80px;
+}
+
+.c2:hover {
+  color: hsl(191,100%,35%);
+}
+
+.c0 {
+  border-collapse: collapse;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.c0 td {
+  padding: 10px 8px;
+  vertical-align: top;
+  border-left: 1px solid rgba(224,224,235,0.4);
+}
+
+.c0 thead td {
+  border: 0;
+  font-weight: bold;
+}
+
+.c0 thead,
+.c0 tbody {
+  border-bottom: 1px solid rgba(224,224,235,0.4);
+  border-left: 3px solid transparent;
+}
+
+<table
+  className="c0"
+>
+  <thead>
+    <tr>
+      <td
+        className="c1"
+        onClick={[Function]}
+      >
+        Name
+         
+        <i
+          className="fa fa-caret-up"
+        />
+      </td>
+      <td
+        className="c2"
+        onClick={[Function]}
+      >
+        Email
+         
+      </td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        Albert
+      </td>
+      <td>
+        b@weave.works
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Bob
+      </td>
+      <td>
+        a@weave.works
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Ty
+      </td>
+      <td>
+        c@weave.works
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
 exports[`DataTable snapshots renders extra headers 1`] = `
 .c1 {
   text-align: left;


### PR DESCRIPTION
Adds some more functionality to cover things like custom header elements and header widths.

Needed for https://github.com/weaveworks/service-ui/issues/2691