### PR TITLE
Get rid of status.error color in favor of different shades of theme orange

### DIFF
--- a/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -8,7 +8,7 @@ exports[`<Alert /> snapshots renders default 1`] = `
   display: flex;
   background: hsl(0,0%,96%);
   border-radius: 4px;
-  border: 2px solid #cfcfcf;
+  border: 2px solid hsl(0,0%,80%);
   color: hsl(0,0%,10%);
   margin: 8px 0 8px 0;
   min-height: 1em;
@@ -55,9 +55,9 @@ exports[`<Alert /> snapshots renders error 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  background: #c7254e;
+  background: hsl(13,100%,40%);
   border-radius: 4px;
-  border: 2px solid #861935;
+  border: 2px solid hsl(13,100%,30%);
   color: hsl(0,0%,100%);
   margin: 8px 0 8px 0;
   min-height: 1em;
@@ -106,7 +106,7 @@ exports[`<Alert /> snapshots renders icon if provided 1`] = `
   display: flex;
   background: hsl(0,0%,96%);
   border-radius: 4px;
-  border: 2px solid #cfcfcf;
+  border: 2px solid hsl(0,0%,80%);
   color: hsl(0,0%,10%);
   margin: 8px 0 8px 0;
   min-height: 1em;
@@ -213,7 +213,7 @@ exports[`<Alert /> snapshots renders title if provided 1`] = `
   display: flex;
   background: hsl(0,0%,96%);
   border-radius: 4px;
-  border: 2px solid #cfcfcf;
+  border: 2px solid hsl(0,0%,80%);
   color: hsl(0,0%,10%);
   margin: 8px 0 8px 0;
   min-height: 1em;

--- a/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/src/components/Button/__snapshots__/Button.test.js.snap
@@ -17,7 +17,7 @@ exports[`<Button /> accepts a style prop 1`] = `
 .c0:hover {
   -webkit-transition: color 0.3s ease;
   transition: color 0.3s ease;
-  background: #f2f2f2;
+  background: hsl(0,0%,96%);
   color: hsl(240,20%,30%);
 }
 
@@ -43,7 +43,7 @@ exports[`<Button /> snapshots renders danger 1`] = `
   border: 0;
   outline: none;
   box-shadow: 0 1px 3px rgba(0,0,0,0.12),0 1px 2px rgba(0,0,0,0.24);
-  background: #c7254e;
+  background: hsl(13,100%,40%);
   color: hsl(0,0%,100%);
   font-size: 14px;
   cursor: pointer;
@@ -52,7 +52,7 @@ exports[`<Button /> snapshots renders danger 1`] = `
 .c0:hover {
   -webkit-transition: color 0.3s ease;
   transition: color 0.3s ease;
-  background: #b12146;
+  background: hsl(13,100%,35%);
   color: hsl(0,0%,100%);
 }
 
@@ -82,7 +82,7 @@ exports[`<Button /> snapshots renders default 1`] = `
 .c0:hover {
   -webkit-transition: color 0.3s ease;
   transition: color 0.3s ease;
-  background: #f2f2f2;
+  background: hsl(0,0%,96%);
   color: hsl(240,20%,30%);
 }
 
@@ -142,7 +142,7 @@ exports[`<Button /> snapshots renders primary 1`] = `
 .c0:hover {
   -webkit-transition: color 0.3s ease;
   transition: color 0.3s ease;
-  background: #007d9a;
+  background: hsl(191,100%,30%);
   color: hsl(0,0%,100%);
 }
 
@@ -172,7 +172,7 @@ exports[`<Button /> snapshots renders selected 1`] = `
 .c0:hover {
   -webkit-transition: color 0.3s ease;
   transition: color 0.3s ease;
-  background: #f2f2f2;
+  background: hsl(0,0%,96%);
   color: hsl(240,20%,30%);
 }
 

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -24,7 +24,7 @@ const Icon = styled.i`
   display: inline-block;
   margin-left: 4px;
   font-size: ${props => props.theme.fontSizes.large};
-  color: ${props => props.theme.colors.status.error};
+  color: ${props => props.theme.colors.orange600};
 `;
 
 const InputWrapper = styled.div`
@@ -54,7 +54,7 @@ const ValidationMessage = styled.span`
   font-size: ${props => props.theme.fontSizes.small};
   padding-left: 8px;
   visibility: ${props => (props.visible ? 'visible' : 'hidden')};
-  color: ${props => (props.valid ? 'inherit' : props.theme.colors.status.error)};
+  color: ${props => (props.valid ? 'inherit' : props.theme.colors.orange600)};
 `;
 
 /**

--- a/src/components/PrometheusGraph/_ErrorOverlay.js
+++ b/src/components/PrometheusGraph/_ErrorOverlay.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 const ErrorContainer = styled.div`
-  color: ${props => props.theme.colors.status.error};
+  color: ${props => props.theme.colors.orange600};
   opacity: ${props => (props.loading ? 0.2 : 1)};
   position: absolute;
   top: 0;

--- a/src/components/Search/__snapshots__/Search.test.js.snap
+++ b/src/components/Search/__snapshots__/Search.test.js.snap
@@ -6,7 +6,7 @@ exports[`<Search /> snapshots renders a group of terms 1`] = `
   display: inline-block;
   margin-left: 4px;
   font-size: 22px;
-  color: #c7254e;
+  color: hsl(13,100%,40%);
 }
 
 .c7 {
@@ -208,7 +208,7 @@ exports[`<Search /> snapshots renders a search string 1`] = `
   display: inline-block;
   margin-left: 4px;
   font-size: 22px;
-  color: #c7254e;
+  color: hsl(13,100%,40%);
 }
 
 .c6 {
@@ -366,7 +366,7 @@ exports[`<Search /> snapshots renders empty 1`] = `
   display: inline-block;
   margin-left: 4px;
   font-size: 22px;
-  color: #c7254e;
+  color: hsl(13,100%,40%);
 }
 
 .c6 {
@@ -524,7 +524,7 @@ exports[`<Search /> snapshots renders filters 1`] = `
   display: inline-block;
   margin-left: 4px;
   font-size: 22px;
-  color: #c7254e;
+  color: hsl(13,100%,40%);
 }
 
 .c6 {

--- a/src/theme/atoms.js
+++ b/src/theme/atoms.js
@@ -8,12 +8,12 @@ export const atoms = {
     default: {
       color: colors.black,
       background: colors.gray50,
-      borderColor: darken(0.15, colors.gray50),
+      borderColor: colors.gray200,
     },
     info: {
       color: colors.white,
       background: colors.blue600,
-      borderColor: darken(0.15, colors.blue600),
+      borderColor: colors.blue800,
     },
     success: {
       color: colors.white,
@@ -27,8 +27,8 @@ export const atoms = {
     },
     error: {
       color: colors.white,
-      background: colors.status.error,
-      borderColor: darken(0.15, colors.status.error),
+      background: colors.orange600,
+      borderColor: colors.orange800,
     },
   },
   Button: {
@@ -36,19 +36,19 @@ export const atoms = {
       color: colors.black,
       background: colors.white,
       hoverColor: colors.purple800,
-      hoverBackground: darken(0.05, colors.white),
+      hoverBackground: colors.gray50,
     },
     primary: {
       color: colors.white,
       background: colors.blue700,
       hoverColor: colors.white,
-      hoverBackground: darken(0.05, colors.blue700),
+      hoverBackground: colors.blue800,
     },
     danger: {
       color: colors.white,
-      background: colors.status.error,
+      background: colors.orange600,
       hoverColor: colors.white,
-      hoverBackground: darken(0.05, colors.status.error),
+      hoverBackground: colors.orange700,
     },
     disabled: {
       color: colors.gray600,

--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -15,7 +15,11 @@ export const colors = {
   purple25: 'hsl(240, 20%, 98%)', // #fafafc
 
   // Accent Colors
+  orange800: 'hsl(13, 100%, 30%)', // #992100
+  orange700: 'hsl(13, 100%, 35%)', // #b32700
+  orange600: 'hsl(13, 100%, 40%)', // #cc2c00
   orange500: 'hsl(13, 100%, 50%)', // #ff3700
+  blue800: 'hsl(191, 100%, 30%)', // #007d99
   blue700: 'hsl(191, 100%, 35%)', // #0092b3
   blue600: 'hsl(191, 100%, 40%)', // #00a7cc
   blue400: 'hsl(191, 100%, 50%)', // #00d2ff
@@ -30,10 +34,9 @@ export const colors = {
   gray50: 'hsl(0, 0%, 96%)', // #f4f4f4
   white: 'hsl(0, 0%, 100%)', // #ffffff
 
-  // Use these when colorizing elements that should indicate a state or outcome, ie Alerts.
+  /* Legacy */
   status: {
     success: '#38bd93', // green
-    error: '#c7254e', // red
     warning: '#d4ab27', // amber
   },
 


### PR DESCRIPTION
Resolves #268.

Affects:

* Danger button
* Error alert
* All error messages

##### Before

![image](https://user-images.githubusercontent.com/1216874/42748237-ad84c5c4-88df-11e8-90a4-530645681fe9.png)
![image](https://user-images.githubusercontent.com/1216874/42748246-b64a8e64-88df-11e8-8aa9-9feefb1ae4de.png)

##### After

![image](https://user-images.githubusercontent.com/1216874/42748280-e37fdc0e-88df-11e8-8386-6d5983dd8434.png)
![image](https://user-images.githubusercontent.com/1216874/42748290-f0833a54-88df-11e8-991a-7ddc960c309e.png)


cc @bia 
