### PR TITLE
make label less than full width

### DIFF
--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -186,7 +186,10 @@ class Dropdown extends React.Component {
         {isOpen && (
           <div>
             <Overlay onClick={this.handleBgClick} />
-            <Popover className="dropdown-popover" width={this.element.current.offsetWidth}>
+            <Popover
+              className="dropdown-popover"
+              width={this.element.current.offsetWidth}
+            >
               {map(
                 divided,
                 (item, index) =>

--- a/src/components/GraphEdge/GraphEdge.js
+++ b/src/components/GraphEdge/GraphEdge.js
@@ -118,7 +118,6 @@ class GraphEdge extends React.Component {
     }
   }
 
-
   prepareWaypointsForMotion({ waypoints, waypointsCap, isAnimated }) {
     // Don't update if the edges are not animated.
     if (!isAnimated) return;
@@ -216,10 +215,12 @@ GraphEdge.propTypes = {
   /**
    * A list of points in the { x, y } format describing the edge path
    */
-  waypoints: PropTypes.arrayOf(PropTypes.shape({
-    x: PropTypes.number.isRequired,
-    y: PropTypes.number.isRequired,
-  })).isRequired,
+  waypoints: PropTypes.arrayOf(
+    PropTypes.shape({
+      x: PropTypes.number.isRequired,
+      y: PropTypes.number.isRequired,
+    })
+  ).isRequired,
   /**
    * A number of waypoints to cap to in case the edge is animated
    */

--- a/src/components/ResourceDial/ResourceDial.js
+++ b/src/components/ResourceDial/ResourceDial.js
@@ -99,6 +99,11 @@ const FillArc = ({ color, value = 1 }) => (
   />
 );
 
+const Label = styled.span`
+  max-width: calc(100% - 40px);
+  text-align: center;
+`;
+
 // TODO: Extract this into the theme.
 const dialSpring = value =>
   spring(value, { stiffness: 50, damping: 13, precision: 0.01 });
@@ -145,7 +150,7 @@ class ResourceDial extends React.PureComponent {
                 </DialValue>
                 {hasValue && <PercentageSign>%</PercentageSign>}
               </DialValueContainer>
-              {label}
+              <Label>{label}</Label>
               <DialArc width="100%" height="100%">
                 <FillArc color={theme.colors.gray100} />
                 <FillArc

--- a/src/components/ResourceDial/example.js
+++ b/src/components/ResourceDial/example.js
@@ -51,7 +51,7 @@ export default class ResourceDialExample extends React.Component {
         <Example>
           <Info>Spectrum of different values</Info>
           <InlineWrapper>
-            <ResourceDial label="CPU usage" value={0} />
+            <ResourceDial label="GPU Memory usage" value={0} />
           </InlineWrapper>
           <InlineWrapper>
             <ResourceDial label="CPU usage" value={0.0001} />


### PR DESCRIPTION
stops collision with ring and pushes label onto newline center text
in preparation for weaveworks/service-ui/issues/2807

 -    fix lints after new config merged

*before*
![image](https://user-images.githubusercontent.com/1794071/42879596-1f453266-8a89-11e8-9b71-49cdedd3818e.png)

*after*
![image](https://user-images.githubusercontent.com/1794071/42879582-0ff95198-8a89-11e8-8790-20b5a0346b00.png)
