### PR TITLE
Extend Dialog component props

### DIFF
--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -1,4 +1,3 @@
-// eslint-disable
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
@@ -7,63 +6,79 @@ import { noop } from 'lodash';
 import Button from '../Button';
 
 const Wrapper = styled.div`
+  z-index: ${props => props.theme.layers.modal};
   transition: opacity 0.2s ease;
+  align-items: center;
   position: fixed;
   display: flex;
-  align-items: center;
   opacity: 0;
   height: 100%;
   left: -100%;
-  top: 0;
   width: 100%;
-  z-index: ${props => props.theme.layers.modal};
+  top: 0;
 
-  &.active {
+  ${props =>
+    props.active &&
+    `
     left: 0;
     opacity: 1;
-  }
+  `};
 `;
 
 const Overlay = styled.div`
   background-color: ${props => props.theme.colors.black};
-  opacity: 0;
   position: absolute;
+  opacity: 0.3;
   height: 100%;
-  left: -100%;
-  top: 0;
   width: 100%;
+  left: 0;
+  top: 0;
 
-  & {
-    opacity: 0.5;
-    left: 0;
-  }
+  /* Currently not supported by most of the browsers, but the future is near :) */
+  backdrop-filter: blur(2px);
 `;
 
 const Window = styled.div`
   box-shadow: ${props => props.theme.boxShadow.light};
   background-color: ${props => props.theme.colors.white};
   color: ${props => props.theme.colors.purple800};
+  width: ${props => props.width};
   margin: 0 auto;
   max-width: 768px;
   padding: 20px;
-  width: 75%;
   position: relative;
 `;
 
-const ButtonClose = styled.div`
-  text-align: right;
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
 
-  & > span:hover {
-    cursor: pointer;
+const Title = styled.span`
+  font-size: ${props => props.theme.fontSizes.large};
+`;
+
+const ButtonClose = styled.button`
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  padding: 5px;
+  outline: 0;
+
+  &:hover {
+    opacity: 0.5;
   }
 `;
+
+const Content = styled.div``;
 
 const Actions = styled.div`
   text-align: right;
   min-height: 36px;
 
-  button:first-child {
-    margin-right: 10px;
+  button {
+    margin-left: 10px;
   }
 `;
 
@@ -106,58 +121,59 @@ const Actions = styled.div`
  * }
  * ```
  */
-class Dialog extends React.Component {
-  handleActionClick = text => {
-    this.props.onActionClick(text);
-  };
-
-  handleClose = () => {
-    this.props.onClose();
-  };
-
-  render() {
-    const { children, active, actions, overlay } = this.props;
-    return (
-      <Wrapper className={active ? 'weave-dialog active' : 'weave-dialog'}>
-        {overlay && (
-          <Overlay
-            onClick={this.handleClose}
-            className="weave-dialog-overlay"
-          />
-        )}
-        <Window className="weave-dialog-window">
-          <ButtonClose className="weave-dialog-close">
-            <span onClick={this.handleClose} className="fa fa-close" />
-          </ButtonClose>
-          <div className="weave-dialog-content">{children}</div>
-          <Actions className="weave-dialog-actions">
-            {actions &&
-              actions.map((Action, i) => {
-                /* eslint react/no-array-index-key: 0 */
-                if (React.isValidElement(Action)) {
-                  return React.cloneElement(Action, { key: i });
-                }
-                return (
-                  <Button
-                    key={i}
-                    onClick={() => this.handleActionClick(Action)}
-                    text={Action}
-                  />
-                );
-                /* eslint react/no-array-index-key: 0 */
-              })}
-          </Actions>
-        </Window>
-      </Wrapper>
-    );
-  }
-}
+const Dialog = ({
+  active,
+  title,
+  width,
+  actions,
+  onActionClick,
+  onClose,
+  children,
+}) => (
+  <Wrapper active={active}>
+    <Overlay onClick={onClose} />
+    <Window width={width}>
+      <Header>
+        <Title>{title}</Title>
+        <ButtonClose text="" onClick={onClose}>
+          <i className="fa fa-close" />
+        </ButtonClose>
+      </Header>
+      <Content>{children}</Content>
+      <Actions>
+        {actions &&
+          actions.map((Action, index) => {
+            if (React.isValidElement(Action)) {
+              /* eslint react/no-array-index-key: 0 */
+              return React.cloneElement(Action, { key: index });
+              /* eslint react/no-array-index-key: 0 */
+            }
+            return (
+              <Button
+                key={Action}
+                text={Action}
+                onClick={() => onActionClick(Action)}
+              />
+            );
+          })}
+      </Actions>
+    </Window>
+  </Wrapper>
+);
 
 Dialog.propTypes = {
   /**
    * Flag to show/hide the dialog
    */
-  active: PropTypes.bool,
+  active: PropTypes.bool.isRequired,
+  /**
+   * The title of the dialog
+   */
+  title: PropTypes.string,
+  /**
+   * Width of the dialog window (CSS format)
+   */
+  width: PropTypes.string,
   /**
    * An array of options that the user will be able to click.
    * Each item in the array will be rendered as a <Button /> in the dialog window.
@@ -165,27 +181,23 @@ Dialog.propTypes = {
    */
   actions: PropTypes.array,
   /**
-   * Callback that will be run when the dialog is closed
-   */
-  onClose: PropTypes.func,
-  /**
    * Callback that runs when an action is clicked by the user. If the actions
    * If the `actions` prop is an array of strings,
    * this callback will return the action that was clicked.
    */
   onActionClick: PropTypes.func,
   /**
-   * Toggles a modal overlay. If set to true, the overlay will appear,
+   * Callback that will be run when the modal is closed
    */
-  overlay: PropTypes.bool,
+  onClose: PropTypes.func,
 };
 
 Dialog.defaultProps = {
+  title: '',
+  width: '75%',
   actions: [],
-  active: false,
   onActionClick: noop,
   onClose: noop,
-  overlay: true,
 };
 
 export default Dialog;

--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -45,7 +45,7 @@ const Window = styled.div`
   width: ${props => props.width};
   margin: 0 auto;
   max-width: 768px;
-  padding: 20px;
+  padding: 15px 20px 20px;
   position: relative;
 `;
 
@@ -56,13 +56,15 @@ const Header = styled.div`
 `;
 
 const Title = styled.span`
-  font-size: ${props => props.theme.fontSizes.large};
+  font-size: ${props => props.theme.fontSizes.normal};
+  font-weight: bold;
 `;
 
 const ButtonClose = styled.button`
   border: 0;
   background: transparent;
   cursor: pointer;
+  margin-right: -5px;
   padding: 5px;
   outline: 0;
 
@@ -144,9 +146,9 @@ const Dialog = ({
         {actions &&
           actions.map((Action, index) => {
             if (React.isValidElement(Action)) {
-              /* eslint react/no-array-index-key: 0 */
+              /* eslint-disable react/no-array-index-key */
               return React.cloneElement(Action, { key: index });
-              /* eslint react/no-array-index-key: 0 */
+              /* eslint-enable react/no-array-index-key */
             }
             return (
               <Button

--- a/src/components/Dialog/Dialog.test.js
+++ b/src/components/Dialog/Dialog.test.js
@@ -7,17 +7,17 @@ describe('<Dialog />', () => {
   it('shows/hides when active/inactive', () => {
     const closeSpy = jest.fn();
     const dialog = shallow(<Dialog active onClose={closeSpy} />);
-    expect(dialog.find('.weave-dialog').hasClass('active')).toBe(true);
-    dialog.find('.weave-dialog-close > span').simulate('click');
+    expect(dialog.get(0).props.active).toBe(true);
+    dialog.find({ text: '' }).simulate('click');
     expect(closeSpy).toBeCalled();
     dialog.setProps({ active: false });
-    expect(dialog.find('.weave-dialog').hasClass('active')).toBe(false);
+    expect(dialog.get(0).props.active).toBe(false);
   });
 
   it('runs the action-click handler', () => {
     const actionSpy = jest.fn();
     const dialog = shallow(
-      <Dialog actions={['Submit', 'Cancel']} onActionClick={actionSpy} />
+      <Dialog active actions={['Submit', 'Cancel']} onActionClick={actionSpy} />
     );
     dialog.find({ text: 'Submit' }).simulate('click');
     expect(actionSpy).toBeCalledWith('Submit');
@@ -28,7 +28,10 @@ describe('<Dialog />', () => {
   it('allows for React elements to be used for actions', () => {
     const newSpy = jest.fn();
     const dialog = shallow(
-      <Dialog actions={[<div className="user-action" onClick={newSpy} />]} />
+      <Dialog
+        active
+        actions={[<div className="user-action" onClick={newSpy} />]}
+      />
     );
     dialog.find('.user-action').simulate('click');
     expect(newSpy).toBeCalled();

--- a/src/components/Dialog/example.js
+++ b/src/components/Dialog/example.js
@@ -7,16 +7,12 @@ import Button from '../Button';
 import Dialog from '.';
 
 export default class DialogExample extends React.Component {
-  constructor(props, context) {
-    super(props, context);
-    this.state = {
-      normalButtonActive: false,
-      otherButtonActive: false,
-    };
-    this.handleDialogActivate = this.handleDialogActivate.bind(this);
-    this.handleClose = this.handleClose.bind(this);
-  }
-  handleDialogActivate(type, args) {
+  state = {
+    normalButtonActive: false,
+    otherButtonActive: false,
+  };
+
+  handleDialogActivate = (type, args) => {
     const key = `${type}ButtonActive`;
     if (this.state[key]) {
       this.props.clickHandler('onActionClick', args);
@@ -24,13 +20,15 @@ export default class DialogExample extends React.Component {
     this.setState({
       [key]: !this.state[key],
     });
-  }
-  handleClose() {
+  };
+
+  handleClose = () => {
     this.setState({
       normalButtonActive: false,
       otherButtonActive: false,
     });
-  }
+  };
+
   render() {
     const Action1 = () => (
       <Button
@@ -64,7 +62,6 @@ export default class DialogExample extends React.Component {
             actions={['Submit', 'Cancel']}
             onClose={this.handleClose}
             onActionClick={this.handleClose}
-            overlay
           >
             <p>Here is some content that I would like to display</p>
           </Dialog>
@@ -83,7 +80,8 @@ export default class DialogExample extends React.Component {
             active={this.state.otherButtonActive}
             actions={[<Action1 />, <Action2 />]}
             onClose={this.handleClose}
-            overlay
+            title="Dialog with title"
+            width="400px"
           >
             <p>This one has custom actions</p>
           </Dialog>


### PR DESCRIPTION
Brings the `Dialog` component closer to / easier to use for https://github.com/weaveworks/service-ui/issues/2813#issuecomment-405962739 (inviting team members to Weave Cloud).
