### PR TITLE
move validation icon inside input

### DIFF
--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -121,7 +121,7 @@ class Input extends React.Component {
         <label htmlFor={id}>{label}</label>
         <InputWrapper valid={valid}>
           {React.createElement(textarea ? 'textarea' : 'input', {
-            ...omit(inputProps, 'autoSelectText'),
+            ...omit(inputProps, 'autoSelectText', 'focus'),
             ref: elem => {
               this.input = elem;
               inputRef(elem);
@@ -132,7 +132,7 @@ class Input extends React.Component {
         <ValidationMessage
           remove={hideValidationMessage}
           valid={valid}
-          visible={message}
+          visible={message && !valid}
         >
           {message}
         </ValidationMessage>
@@ -142,6 +142,14 @@ class Input extends React.Component {
 }
 
 Input.propTypes = {
+  /*
+   * Select the text inside the input. Requires focus attribute to be true
+   */
+  autoSelectText: PropTypes.bool,
+  /*
+   * Focus the input on render
+   */
+  focus: PropTypes.bool,
   /*
    * Remove the validation message from the DOM
    */
@@ -174,6 +182,8 @@ Input.propTypes = {
 };
 
 Input.defaultProps = {
+  autoSelectText: false,
+  focus: false,
   hideValidationMessage: false,
   inputRef: noop,
   label: '',

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -20,26 +20,26 @@ const placeholder = (property, content) => css`
 `;
 
 const Icon = styled.i`
+  position: absolute;
+  right: 10px;
   visibility: ${props => (props.visible ? 'visible' : 'hidden')};
-  display: inline-block;
-  margin-left: 4px;
   font-size: ${props => props.theme.fontSizes.large};
   color: ${props => props.theme.colors.orange600};
 `;
 
 const InputWrapper = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
   margin-top: 10px;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
   height: 36px;
-`;
-
-const StyledInput = component => styled(component)`
-  padding: 8px;
 
   input {
-    ${props => placeholder(props.theme.colors.gray600)};
-    display: inline-block;
-    padding: 0 12px;
+    ${props => placeholder('color', props.theme.colors.gray600)};
+    padding-right: ${props => (props.valid ? '12px' : '38px')};
+    padding-left: 12px;
+    width: 100%;
     line-height: 36px;
     box-shadow: none;
     border: 1px solid ${props => props.theme.colors.gray600};
@@ -49,12 +49,17 @@ const StyledInput = component => styled(component)`
   }
 `;
 
+const StyledInput = component => styled(component)`
+  padding: 8px;
+`;
+
 const ValidationMessage = styled.span`
   display: ${props => (props.remove ? 'none' : 'block')};
-  font-size: ${props => props.theme.fontSizes.small};
   padding-left: 8px;
-  visibility: ${props => (props.visible ? 'visible' : 'hidden')};
+  font-size: ${props => props.theme.fontSizes.small};
+  text-align: left;
   color: ${props => (props.valid ? 'inherit' : props.theme.colors.orange600)};
+  visibility: ${props => (props.visible ? 'visible' : 'hidden')};
 `;
 
 /**
@@ -100,21 +105,21 @@ class Input extends React.Component {
 
   render() {
     const {
-      valid,
-      message,
-      label,
-      id,
       className,
-      textarea,
       hideValidationMessage,
+      id,
       inputRef,
+      label,
+      message,
+      textarea,
+      valid,
       ...inputProps
     } = this.props;
 
     return (
       <div className={className}>
         <label htmlFor={id}>{label}</label>
-        <InputWrapper>
+        <InputWrapper valid={valid}>
           {React.createElement(textarea ? 'textarea' : 'input', {
             ...omit(inputProps, 'autoSelectText'),
             ref: elem => {
@@ -137,6 +142,14 @@ class Input extends React.Component {
 }
 
 Input.propTypes = {
+  /*
+   * Remove the validation message from the DOM
+   */
+  hideValidationMessage: PropTypes.bool,
+  /**
+   * A callback to which the input `ref` will be passed.
+   */
+  inputRef: PropTypes.func,
   /**
    * The label that will appear above the input field
    */
@@ -147,10 +160,6 @@ Input.propTypes = {
    */
   message: PropTypes.any,
   /**
-   * Whether or not the form value is valid. The icon will not appear when `valid` is truthy.
-   */
-  valid: PropTypes.bool,
-  /**
    * Callback to run when the input is edited by the user
    */
   onChange: PropTypes.func,
@@ -159,12 +168,13 @@ Input.propTypes = {
    */
   textarea: PropTypes.bool,
   /**
-   * A callback to which the input `ref` will be passed.
+   * Whether or not the form value is valid. The icon will not appear when `valid` is truthy.
    */
-  inputRef: PropTypes.func,
+  valid: PropTypes.bool,
 };
 
 Input.defaultProps = {
+  hideValidationMessage: false,
   inputRef: noop,
   label: '',
   message: '',

--- a/src/components/Input/Input.test.js
+++ b/src/components/Input/Input.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import enzyme, { mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import 'jest-styled-components';
+
+import { withTheme } from '../../utils/theme';
+
+import Input from './Input';
+
+enzyme.configure({ adapter: new Adapter() });
+
+describe('<Input />', () => {
+  let props;
+  let wrapper;
+  let onChange;
+
+  beforeEach(() => {
+    onChange = jest.fn();
+
+    props = {
+      label: 'Hi',
+      valid: false,
+      message: 'Doh!',
+      onChange,
+    };
+
+    wrapper = mount(withTheme(<Input {...props} />));
+  });
+
+  it('should call onChange on input', () => {
+    expect(onChange).not.toHaveBeenCalled();
+
+    wrapper.find('input').simulate('change');
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not render validation message when valid=true', () => {
+    props = {
+      valid: true,
+      message: 'Derp!',
+    };
+    wrapper = mount(withTheme(<Input {...props} />), {
+      lifecycleExperimental: true,
+    });
+
+    expect(wrapper.find('Input__ValidationMessage')).toHaveStyleRule(
+      'visibility',
+      'hidden'
+    );
+  });
+
+  it('should render validation message when valid=false', () => {
+    props = {
+      valid: false,
+      message: 'Derp!',
+    };
+    wrapper = mount(withTheme(<Input {...props} />));
+
+    expect(wrapper.find('Input__ValidationMessage')).toHaveStyleRule(
+      'visibility',
+      'visible'
+    );
+  });
+
+  it('should remove validation message from the DOM when hideValidationMessage=true', () => {
+    props = {
+      hideValidationMessage: true,
+    };
+    wrapper = mount(withTheme(<Input {...props} />));
+
+    expect(wrapper.find('Input__ValidationMessage')).toHaveStyleRule(
+      'display',
+      'none'
+    );
+  });
+
+  it('should render correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/Input/__snapshots__/Input.test.js.snap
+++ b/src/components/Input/__snapshots__/Input.test.js.snap
@@ -1,0 +1,306 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Input /> should render correctly 1`] = `
+.c2 {
+  position: absolute;
+  right: 10px;
+  visibility: visible;
+  font-size: 22px;
+  color: hsl(13,100%,40%);
+}
+
+.c1 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-top: 10px;
+  margin-bottom: 8px;
+  height: 36px;
+}
+
+.c1 input {
+  padding-right: 38px;
+  padding-left: 12px;
+  width: 100%;
+  line-height: 36px;
+  box-shadow: none;
+  border: 1px solid hsl(0,0%,45%);
+  border-radius: 4px;
+  height: 36px;
+  box-sizing: border-box;
+}
+
+.c1 input::-webkit-input-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c1 input::-moz-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c1 input:-moz-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c1 input:-ms-input-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c3 {
+  display: block;
+  padding-left: 8px;
+  font-size: 14px;
+  text-align: left;
+  color: hsl(13,100%,40%);
+  visibility: visible;
+}
+
+.c0 {
+  padding: 8px;
+}
+
+<ThemeProvider
+  theme={
+    Object {
+      "atoms": Object {
+        "Alert": Object {
+          "default": Object {
+            "background": "hsl(0, 0%, 96%)",
+            "borderColor": "hsl(0, 0%, 80%)",
+            "color": "hsl(0, 0%, 10%)",
+          },
+          "error": Object {
+            "background": "hsl(13, 100%, 40%)",
+            "borderColor": "hsl(13, 100%, 30%)",
+            "color": "hsl(0, 0%, 100%)",
+          },
+          "info": Object {
+            "background": "hsl(191, 100%, 40%)",
+            "borderColor": "hsl(191, 100%, 30%)",
+            "color": "hsl(0, 0%, 100%)",
+          },
+          "success": Object {
+            "background": "#38bd93",
+            "borderColor": "#278265",
+            "color": "hsl(0, 0%, 100%)",
+          },
+          "warning": Object {
+            "background": "#d4ab27",
+            "borderColor": "#93771b",
+            "color": "hsl(0, 0%, 100%)",
+          },
+        },
+        "Button": Object {
+          "danger": Object {
+            "background": "hsl(13, 100%, 40%)",
+            "color": "hsl(0, 0%, 100%)",
+            "hoverBackground": "hsl(13, 100%, 35%)",
+            "hoverColor": "hsl(0, 0%, 100%)",
+          },
+          "default": Object {
+            "background": "hsl(0, 0%, 100%)",
+            "color": "hsl(0, 0%, 10%)",
+            "hoverBackground": "hsl(0, 0%, 96%)",
+            "hoverColor": "hsl(240, 20%, 30%)",
+          },
+          "disabled": Object {
+            "background": "hsl(0, 0%, 96%)",
+            "color": "hsl(0, 0%, 45%)",
+            "hoverBackground": "hsl(0, 0%, 96%)",
+            "hoverColor": "hsl(0, 0%, 45%)",
+          },
+          "primary": Object {
+            "background": "hsl(191, 100%, 35%)",
+            "color": "hsl(0, 0%, 100%)",
+            "hoverBackground": "hsl(191, 100%, 30%)",
+            "hoverColor": "hsl(0, 0%, 100%)",
+          },
+        },
+      },
+      "borderRadius": Object {
+        "circle": "50%",
+        "none": "0",
+        "soft": "4px",
+      },
+      "boxShadow": Object {
+        "heavy": "0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23)",
+        "light": "0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24)",
+        "none": "none",
+        "selected": "0px 0px 2px 2px hsl(240, 20%, 60%)",
+      },
+      "colors": Object {
+        "black": "hsl(0, 0%, 10%)",
+        "blue200": "hsl(191, 100%, 80%)",
+        "blue400": "hsl(191, 100%, 50%)",
+        "blue50": "hsl(191, 100%, 97%)",
+        "blue600": "hsl(191, 100%, 40%)",
+        "blue700": "hsl(191, 100%, 35%)",
+        "blue800": "hsl(191, 100%, 30%)",
+        "graphThemes": Object {
+          "blue": Array [
+            "#c7e9b4",
+            "#7ecdbb",
+            "#1eb5eb",
+            "#1d91bf",
+            "#235fa9",
+            "#253393",
+            "#084181",
+          ],
+          "mixed": Array [
+            "#c7e9b4",
+            "#c1d4e7",
+            "#7ecdbb",
+            "#9fbddb",
+            "#1eb5eb",
+            "#8d95c6",
+            "#1d91bf",
+            "#8282ab",
+            "#235fa9",
+            "#89429e",
+            "#253393",
+            "#800f7a",
+            "#084181",
+            "#0b0533",
+          ],
+          "purple": Array [
+            "#c1d4e7",
+            "#9fbddb",
+            "#8d95c6",
+            "#8282ab",
+            "#89429e",
+            "#800f7a",
+            "#0b0533",
+          ],
+        },
+        "gray100": "hsl(0, 0%, 90%)",
+        "gray200": "hsl(0, 0%, 80%)",
+        "gray50": "hsl(0, 0%, 96%)",
+        "gray600": "hsl(0, 0%, 45%)",
+        "orange500": "hsl(13, 100%, 50%)",
+        "orange600": "hsl(13, 100%, 40%)",
+        "orange700": "hsl(13, 100%, 35%)",
+        "orange800": "hsl(13, 100%, 30%)",
+        "promQL": Object {
+          "attrName": "#00a4db",
+          "comment": "#bbbbbb",
+          "deleted": "#9a050f",
+          "entity": "#36acaa",
+          "function": "#dc322f",
+          "metricName": "#2aa198",
+          "punctuation": "#393a34",
+          "salmon": "#ff7c7c",
+          "string": "#e3116c",
+          "tag": "#00009f",
+        },
+        "purple100": "hsl(240, 20%, 90%)",
+        "purple200": "hsl(240, 20%, 75%)",
+        "purple25": "hsl(240, 20%, 98%)",
+        "purple300": "hsl(240, 20%, 65%)",
+        "purple400": "hsl(240, 20%, 60%)",
+        "purple50": "hsl(240, 20%, 95%)",
+        "purple500": "hsl(240, 20%, 50%)",
+        "purple600": "hsl(240, 20%, 45%)",
+        "purple700": "hsl(240, 20%, 35%)",
+        "purple800": "hsl(240, 20%, 30%)",
+        "purple900": "hsl(240, 20%, 25%)",
+        "status": Object {
+          "success": "#38bd93",
+          "warning": "#d4ab27",
+        },
+        "thirdParty": Object {
+          "azure": "#3769bb",
+          "cornflowerBlue": "#4285f4",
+        },
+        "white": "hsl(0, 0%, 100%)",
+      },
+      "fontFamilies": Object {
+        "monospace": "'Roboto Mono', monospace",
+        "regular": "'proxima-nova', Helvetica, Arial, sans-serif",
+      },
+      "fontSizes": Object {
+        "extraLarge": "32px",
+        "huge": "48px",
+        "large": "22px",
+        "normal": "16px",
+        "small": "14px",
+        "tiny": "12px",
+      },
+      "layers": Object {
+        "alert": 3,
+        "dropdown": 5,
+        "front": 1,
+        "modal": 7,
+        "notification": 4,
+        "toolbar": 2,
+        "tooltip": 6,
+      },
+      "overlayIconSize": "300px",
+      "textColor": "hsl(0, 0%, 10%)",
+    }
+  }
+>
+  <Input
+    label="Hi"
+    message="Doh!"
+    onChange={[Function]}
+    valid={false}
+  >
+    <Input
+      autoSelectText={false}
+      className="c0"
+      focus={false}
+      hideValidationMessage={false}
+      inputRef={[Function]}
+      label="Hi"
+      message="Doh!"
+      onChange={[Function]}
+      textarea={false}
+      valid={false}
+    >
+      <div
+        className="c0"
+      >
+        <label>
+          Hi
+        </label>
+        <Input__InputWrapper
+          valid={false}
+        >
+          <div
+            className="c1"
+          >
+            <input
+              onChange={[Function]}
+            />
+            <Input__Icon
+              className="fa fa-times-circle"
+              visible={true}
+            >
+              <i
+                className="fa fa-times-circle c2"
+              />
+            </Input__Icon>
+          </div>
+        </Input__InputWrapper>
+        <Input__ValidationMessage
+          remove={false}
+          valid={false}
+          visible={true}
+        >
+          <span
+            className="c3"
+          >
+            Doh!
+          </span>
+        </Input__ValidationMessage>
+      </div>
+    </Input>
+  </Input>
+</ThemeProvider>
+`;

--- a/src/components/Input/example.js
+++ b/src/components/Input/example.js
@@ -5,35 +5,56 @@ import { Example, Info } from '../../utils/example';
 
 import Input from '.';
 
-const onChange = () => null;
-
 const StyledExample = styled(Example)`
   width: 250px;
 `;
 
-export default function InputExample() {
-  return (
-    <div>
-      <StyledExample>
-        <Info>Plain inputs</Info>
-        <Input
-          label="Username"
-          placeholder="your name here"
-          onChange={onChange}
-        />
-        <Input label="Email" value="ron@hogwarts.edu" onChange={onChange} />
-      </StyledExample>
-      <StyledExample>
-        <Info>With validation</Info>
-        <Input
-          label="Email"
-          value="invalid-email-that is really long"
-          valid={false}
-          message="Bro, do you even email?"
-          onChange={onChange}
-        />
-        <Input label="Password" type="password" onChange={onChange} />
-      </StyledExample>
-    </div>
-  );
+const isEmail = str => str.indexOf('@') !== -1 && str.indexOf('.') !== -1;
+
+export default class InputExample extends React.Component {
+  state = {
+    invalidValue: 'invalid-email-that is really long',
+    valid: false,
+  };
+
+  onChange = e => {
+    this.setState({
+      invalidValue: e.target.value,
+      valid: isEmail(e.target.value),
+    });
+  };
+
+  render() {
+    return (
+      <div>
+        <StyledExample>
+          <Info>Plain inputs</Info>
+          <Input label="Username" placeholder="your name here" />
+          <Input label="Email" value="ron@hogwarts.edu" />
+        </StyledExample>
+        <StyledExample>
+          <Info>
+            With validation <em>(add valid email to clear)</em>
+          </Info>
+          <Input
+            label="Email"
+            value={this.state.invalidValue}
+            valid={this.state.valid}
+            message="Bro, do you even email?"
+            onChange={this.onChange}
+          />
+          <Input label="Password" type="password" />
+        </StyledExample>
+        <StyledExample>
+          <Info>Autoselect</Info>
+          <Input
+            autoSelectText
+            focus
+            label="Email"
+            value="Autoselect all the things"
+          />
+        </StyledExample>
+      </div>
+    );
+  }
 }

--- a/src/components/Input/example.js
+++ b/src/components/Input/example.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components';
 
 import { Example, Info } from '../../utils/example';
 
@@ -6,10 +7,14 @@ import Input from '.';
 
 const onChange = () => null;
 
+const StyledExample = styled(Example)`
+  width: 250px;
+`;
+
 export default function InputExample() {
   return (
     <div>
-      <Example>
+      <StyledExample>
         <Info>Plain inputs</Info>
         <Input
           label="Username"
@@ -17,18 +22,18 @@ export default function InputExample() {
           onChange={onChange}
         />
         <Input label="Email" value="ron@hogwarts.edu" onChange={onChange} />
-      </Example>
-      <Example>
+      </StyledExample>
+      <StyledExample>
         <Info>With validation</Info>
         <Input
           label="Email"
-          value="invalid-email"
+          value="invalid-email-that is really long"
           valid={false}
           message="Bro, do you even email?"
           onChange={onChange}
         />
         <Input label="Password" type="password" onChange={onChange} />
-      </Example>
+      </StyledExample>
     </div>
   );
 }

--- a/src/components/Search/__snapshots__/Search.test.js.snap
+++ b/src/components/Search/__snapshots__/Search.test.js.snap
@@ -2,40 +2,67 @@
 
 exports[`<Search /> snapshots renders a group of terms 1`] = `
 .c8 {
+  position: absolute;
+  right: 10px;
   visibility: hidden;
-  display: inline-block;
-  margin-left: 4px;
   font-size: 22px;
   color: hsl(13,100%,40%);
 }
 
 .c7 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   margin-top: 10px;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
   height: 36px;
 }
 
-.c9 {
-  display: none;
-  font-size: 14px;
-  padding-left: 8px;
-  visibility: hidden;
-  color: inherit;
-}
-
-.c6 {
-  padding: 8px;
-}
-
-.c6 input {
-  display: inline-block;
-  padding: 0 12px;
+.c7 input {
+  padding-right: 12px;
+  padding-left: 12px;
+  width: 100%;
   line-height: 36px;
   box-shadow: none;
   border: 1px solid hsl(0,0%,45%);
   border-radius: 4px;
   height: 36px;
   box-sizing: border-box;
+}
+
+.c7 input::-webkit-input-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c7 input::-moz-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c7 input:-moz-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c7 input:-ms-input-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c9 {
+  display: none;
+  padding-left: 8px;
+  font-size: 14px;
+  text-align: left;
+  color: inherit;
+  visibility: hidden;
+}
+
+.c6 {
+  padding: 8px;
 }
 
 .c4 {
@@ -208,40 +235,67 @@ exports[`<Search /> snapshots renders a group of terms 1`] = `
 
 exports[`<Search /> snapshots renders a search string 1`] = `
 .c7 {
+  position: absolute;
+  right: 10px;
   visibility: hidden;
-  display: inline-block;
-  margin-left: 4px;
   font-size: 22px;
   color: hsl(13,100%,40%);
 }
 
 .c6 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   margin-top: 10px;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
   height: 36px;
 }
 
-.c8 {
-  display: none;
-  font-size: 14px;
-  padding-left: 8px;
-  visibility: hidden;
-  color: inherit;
-}
-
-.c5 {
-  padding: 8px;
-}
-
-.c5 input {
-  display: inline-block;
-  padding: 0 12px;
+.c6 input {
+  padding-right: 12px;
+  padding-left: 12px;
+  width: 100%;
   line-height: 36px;
   box-shadow: none;
   border: 1px solid hsl(0,0%,45%);
   border-radius: 4px;
   height: 36px;
   box-sizing: border-box;
+}
+
+.c6 input::-webkit-input-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c6 input::-moz-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c6 input:-moz-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c6 input:-ms-input-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c8 {
+  display: none;
+  padding-left: 8px;
+  font-size: 14px;
+  text-align: left;
+  color: inherit;
+  visibility: hidden;
+}
+
+.c5 {
+  padding: 8px;
 }
 
 .c3 {
@@ -370,40 +424,67 @@ exports[`<Search /> snapshots renders a search string 1`] = `
 
 exports[`<Search /> snapshots renders empty 1`] = `
 .c7 {
+  position: absolute;
+  right: 10px;
   visibility: hidden;
-  display: inline-block;
-  margin-left: 4px;
   font-size: 22px;
   color: hsl(13,100%,40%);
 }
 
 .c6 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   margin-top: 10px;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
   height: 36px;
 }
 
-.c8 {
-  display: none;
-  font-size: 14px;
-  padding-left: 8px;
-  visibility: hidden;
-  color: inherit;
-}
-
-.c5 {
-  padding: 8px;
-}
-
-.c5 input {
-  display: inline-block;
-  padding: 0 12px;
+.c6 input {
+  padding-right: 12px;
+  padding-left: 12px;
+  width: 100%;
   line-height: 36px;
   box-shadow: none;
   border: 1px solid hsl(0,0%,45%);
   border-radius: 4px;
   height: 36px;
   box-sizing: border-box;
+}
+
+.c6 input::-webkit-input-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c6 input::-moz-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c6 input:-moz-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c6 input:-ms-input-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c8 {
+  display: none;
+  padding-left: 8px;
+  font-size: 14px;
+  text-align: left;
+  color: inherit;
+  visibility: hidden;
+}
+
+.c5 {
+  padding: 8px;
 }
 
 .c3 {
@@ -532,40 +613,67 @@ exports[`<Search /> snapshots renders empty 1`] = `
 
 exports[`<Search /> snapshots renders filters 1`] = `
 .c7 {
+  position: absolute;
+  right: 10px;
   visibility: hidden;
-  display: inline-block;
-  margin-left: 4px;
   font-size: 22px;
   color: hsl(13,100%,40%);
 }
 
 .c6 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   margin-top: 10px;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
   height: 36px;
 }
 
-.c8 {
-  display: none;
-  font-size: 14px;
-  padding-left: 8px;
-  visibility: hidden;
-  color: inherit;
-}
-
-.c5 {
-  padding: 8px;
-}
-
-.c5 input {
-  display: inline-block;
-  padding: 0 12px;
+.c6 input {
+  padding-right: 12px;
+  padding-left: 12px;
+  width: 100%;
   line-height: 36px;
   box-shadow: none;
   border: 1px solid hsl(0,0%,45%);
   border-radius: 4px;
   height: 36px;
   box-sizing: border-box;
+}
+
+.c6 input::-webkit-input-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c6 input::-moz-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c6 input:-moz-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c6 input:-ms-input-placeholder {
+  color: hsl(0,0%,45%);
+}
+
+.c8 {
+  display: none;
+  padding-left: 8px;
+  font-size: 14px;
+  text-align: left;
+  color: inherit;
+  visibility: hidden;
+}
+
+.c5 {
+  padding: 8px;
 }
 
 .c13 {


### PR DESCRIPTION
-  validation icon caused change of dimensions and alignment when appearing
  next to the input. This commit moves the icon inside the inputa nd adds a
  padding so the content doesn't go underneath the icon.

- add proptypes, add test, update examples input


fixes #315 
The change to `input` being `width: 100%` will have an impact on existing uses of `Input`. I could only find one instance in service-ui where the inputs were being used without width being explicitly set, in the cloudwatch instructions. I have addressed that in https://github.com/weaveworks/service-ui/pull/2932

![image](https://user-images.githubusercontent.com/1794071/43152415-6321ae24-8f66-11e8-9393-841d16327dc0.png)
