### PR TITLE
tweak rules around validation display

### DIFF
--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -32,7 +32,6 @@ const InputWrapper = styled.div`
   display: flex;
   align-items: center;
   margin-top: 10px;
-  margin-bottom: 8px;
   height: 36px;
 
   input {
@@ -54,8 +53,9 @@ const StyledInput = component => styled(component)`
 `;
 
 const ValidationMessage = styled.span`
-  display: ${props => (props.remove ? 'none' : 'block')};
+  display: ${props => (props.remove || !props.visible ? 'none' : 'block')};
   padding-left: 8px;
+  margin-top: 8px;
   font-size: ${props => props.theme.fontSizes.small};
   text-align: left;
   color: ${props => (props.valid ? 'inherit' : props.theme.colors.orange600)};

--- a/src/components/Input/__snapshots__/Input.test.js.snap
+++ b/src/components/Input/__snapshots__/Input.test.js.snap
@@ -20,7 +20,6 @@ exports[`<Input /> should render correctly 1`] = `
   -ms-flex-align: center;
   align-items: center;
   margin-top: 10px;
-  margin-bottom: 8px;
   height: 36px;
 }
 
@@ -55,6 +54,7 @@ exports[`<Input /> should render correctly 1`] = `
 .c3 {
   display: block;
   padding-left: 8px;
+  margin-top: 8px;
   font-size: 14px;
   text-align: left;
   color: hsl(13,100%,40%);

--- a/src/components/Search/__snapshots__/Search.test.js.snap
+++ b/src/components/Search/__snapshots__/Search.test.js.snap
@@ -20,7 +20,6 @@ exports[`<Search /> snapshots renders a group of terms 1`] = `
   -ms-flex-align: center;
   align-items: center;
   margin-top: 10px;
-  margin-bottom: 8px;
   height: 36px;
 }
 
@@ -55,6 +54,7 @@ exports[`<Search /> snapshots renders a group of terms 1`] = `
 .c9 {
   display: none;
   padding-left: 8px;
+  margin-top: 8px;
   font-size: 14px;
   text-align: left;
   color: inherit;
@@ -255,7 +255,6 @@ exports[`<Search /> snapshots renders a search string 1`] = `
   -ms-flex-align: center;
   align-items: center;
   margin-top: 10px;
-  margin-bottom: 8px;
   height: 36px;
 }
 
@@ -290,6 +289,7 @@ exports[`<Search /> snapshots renders a search string 1`] = `
 .c8 {
   display: none;
   padding-left: 8px;
+  margin-top: 8px;
   font-size: 14px;
   text-align: left;
   color: inherit;
@@ -446,7 +446,6 @@ exports[`<Search /> snapshots renders empty 1`] = `
   -ms-flex-align: center;
   align-items: center;
   margin-top: 10px;
-  margin-bottom: 8px;
   height: 36px;
 }
 
@@ -481,6 +480,7 @@ exports[`<Search /> snapshots renders empty 1`] = `
 .c8 {
   display: none;
   padding-left: 8px;
+  margin-top: 8px;
   font-size: 14px;
   text-align: left;
   color: inherit;
@@ -637,7 +637,6 @@ exports[`<Search /> snapshots renders filters 1`] = `
   -ms-flex-align: center;
   align-items: center;
   margin-top: 10px;
-  margin-bottom: 8px;
   height: 36px;
 }
 
@@ -672,6 +671,7 @@ exports[`<Search /> snapshots renders filters 1`] = `
 .c8 {
   display: none;
   padding-left: 8px;
+  margin-top: 8px;
   font-size: 14px;
   text-align: left;
   color: inherit;


### PR DESCRIPTION
Only show the message if there is a message value *and* the field
is invalid.
Move the margin for spacing between input and message to the message
itself so the space is not there when the message is not.

related #324

Spacing before has message margin even though there is no message to show:
![image](https://user-images.githubusercontent.com/1794071/43336708-cbed3a26-91c9-11e8-903f-798060491b9b.png)


![input_after](https://user-images.githubusercontent.com/1794071/43336667-add87820-91c9-11e8-8d3d-396b23f875ae.gif)
