### PR TITLE
only render children when the dialog is active

### DIFF
--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -145,7 +145,7 @@ const Dialog = ({
           </ButtonClose>
         )}
       </Header>
-      <Content>{children}</Content>
+      <Content>{active && children}</Content>
       {!isEmpty(actions) && (
         <Actions>
           {actions.map((Action, index) => {

--- a/src/components/Dialog/Dialog.test.js
+++ b/src/components/Dialog/Dialog.test.js
@@ -1,5 +1,8 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
+
+import 'jest-styled-components';
+import { withTheme } from '../../utils/theme';
 
 import Dialog from './Dialog';
 
@@ -38,11 +41,34 @@ describe('<Dialog />', () => {
   });
 
   it('should hide close icon when hideClose=true', () => {
-    const wrapper = shallow(<Dialog />);
+    const wrapper = shallow(<Dialog active />);
     expect(wrapper.find('i.fa.fa-close').length).toBe(1);
     wrapper.setProps({
       hideClose: true,
     });
     expect(wrapper.find('i.fa.fa-close').length).toBe(0);
+  });
+
+  it('should only render child when active', () => {
+    const heavyFn = jest.fn();
+    const Child = () => {
+      heavyFn();
+      return <div>Metal</div>;
+    };
+    const wrapper = mount(
+      withTheme(
+        <Dialog active={false}>
+          <Child />
+        </Dialog>
+      )
+    );
+    expect(heavyFn).not.toHaveBeenCalled();
+    wrapper.setProps({
+      active: true,
+    });
+
+    setTimeout(() => {
+      expect(heavyFn).toHaveBeenCalledTimes(1);
+    }, 0);
   });
 });


### PR DESCRIPTION
Due to being hidden with css only, and still added to the DOM, any child
component is instantiated when the containing page is rendered.
If you have  a Dialog child with any heavy computation, or any at all
for that matter, you would be doing it even though the dialog may never
be opened.
This commit changes that by only rendering the children when the dialog is
active.

fixes #357