### PR TITLE
add format for compact absolute timestamp

### DIFF
--- a/src/components/TimestampTag/TimestampTag.js
+++ b/src/components/TimestampTag/TimestampTag.js
@@ -109,7 +109,9 @@ class TimestampTag extends React.Component {
       >
         {relative
           ? momentTimestamp.locale(relativeLocale).fromNow(compact)
-          : momentTimestamp.startOf('second').format()}
+          : momentTimestamp
+              .startOf('second')
+              .format(compact ? 'YYYY-MM-DD' : '')}
       </Timestamp>
     );
   }

--- a/src/components/TimestampTag/example.js
+++ b/src/components/TimestampTag/example.js
@@ -40,6 +40,8 @@ export default class TimestampTagExample extends React.Component {
           />
           <Info>Absolute timestamp</Info>
           <TimestampTag timestamp={inputTimestamp} />
+          <Info>Absolute timestamp (compact)</Info>
+          <TimestampTag compact timestamp={inputTimestamp} />
           <Info>Relative timestamp (default)</Info>
           <TimestampTag relative timestamp={inputTimestamp} />
           <Info>Relative timestamp (compact)</Info>


### PR DESCRIPTION
If timestamp is absolute and compact, only show the date.

FOr new events UI design we show the date if more than 7days ago. We currently
don't  use absolute timestamp anywhere so this is low impact.

![image](https://user-images.githubusercontent.com/1794071/45420100-2bff7b00-b681-11e8-9ec1-24d8c72e04aa.png)
