### PR TITLE
Add camera tag to GraphNode component

### DIFF
--- a/src/components/GraphNode/GraphNode.js
+++ b/src/components/GraphNode/GraphNode.js
@@ -5,7 +5,11 @@ import { spring, Motion } from 'react-motion';
 
 import theme from '../../theme';
 
-import GraphNodeStatic, { shapes, nodeBaseSize } from './_GraphNodeStatic';
+import GraphNodeStatic, {
+  shapes,
+  tags,
+  nodeBaseSize,
+} from './_GraphNodeStatic';
 
 function weakSpring(value) {
   return spring(value, { stiffness: 100, damping: 18, precision: 1 });
@@ -61,6 +65,10 @@ GraphNode.propTypes = {
    * Shape of the rendered node (e.g. 'hexagon')
    */
   shape: PropTypes.oneOf(keys(shapes)).isRequired,
+  /**
+   * An optional tag icon attached to the shape
+   */
+  tag: PropTypes.oneOf(keys(tags)),
   /**
    * The node main label displayed right under the node shape
    */
@@ -156,6 +164,7 @@ GraphNode.propTypes = {
 };
 
 GraphNode.defaultProps = {
+  tag: 'none',
   labelMinor: '',
   labelOffset: 0,
   stacked: false,

--- a/src/components/GraphNode/_GraphNodeStatic.js
+++ b/src/components/GraphNode/_GraphNodeStatic.js
@@ -17,6 +17,7 @@ import ShapeCloud from './shapes/_ShapeCloud';
 import ShapeSheet from './shapes/_ShapeSheet';
 import ShapeCylinder from './shapes/_ShapeCylinder';
 import ShapeDottedCylinder from './shapes/_ShapeDottedCylinder';
+import TagCamera from './tags/_TagCamera';
 
 export const nodeBaseSize = 55;
 export const shapes = {
@@ -31,6 +32,10 @@ export const shapes = {
   sheet: ShapeSheet,
   cylinder: ShapeCylinder,
   dottedcylinder: ShapeDottedCylinder,
+};
+export const tags = {
+  none: () => null,
+  camera: TagCamera,
 };
 
 const labelWidth = nodeBaseSize * 2.5;
@@ -179,6 +184,7 @@ class GraphNodeStatic extends React.PureComponent {
 
   render() {
     const Shape = shapes[this.props.shape];
+    const Tag = tags[this.props.tag];
 
     return (
       <GraphNodeWrapper
@@ -204,6 +210,8 @@ class GraphNodeStatic extends React.PureComponent {
           highlighted={this.props.highlighted}
           contrastMode={this.props.contrastMode}
         />
+
+        <Tag contrastMode={this.props.contrastMode} />
       </GraphNodeWrapper>
     );
   }
@@ -212,6 +220,7 @@ class GraphNodeStatic extends React.PureComponent {
 GraphNodeStatic.propTypes = {
   id: PropTypes.string.isRequired,
   shape: PropTypes.oneOf(keys(shapes)).isRequired,
+  tag: PropTypes.oneOf(keys(tags)).isRequired,
   label: PropTypes.string.isRequired,
   labelMinor: PropTypes.string.isRequired,
   labelOffset: PropTypes.number.isRequired,

--- a/src/components/GraphNode/example.js
+++ b/src/components/GraphNode/example.js
@@ -40,10 +40,25 @@ const TextInput = styled.input.attrs({
 
 export default class GraphNodeExample extends React.Component {
   state = {
-    availableShapes: nodeTypes.map(shape => ({
-      shape,
-      key: faker.lorem.slug(),
-    })),
+    availableShapes: [
+      ...nodeTypes.map(shape => ({
+        shape,
+        label: shape,
+        key: faker.lorem.slug(),
+      })),
+      {
+        tag: 'camera',
+        shape: 'cylinder',
+        label: 'cylinder + camera',
+        key: faker.lorem.slug(),
+      },
+      {
+        tag: 'camera',
+        shape: 'dottedcylinder',
+        label: 'dottedcylinder + camera',
+        key: faker.lorem.slug(),
+      },
+    ],
     stackedShape: nodeTypes.map(shape => ({
       shape,
       key: faker.lorem.slug(),
@@ -132,7 +147,8 @@ export default class GraphNodeExample extends React.Component {
               <GraphNode
                 id={node.key}
                 shape={node.shape}
-                label={node.shape}
+                tag={node.tag}
+                label={node.label}
                 size={this.state.size}
                 contrastMode={this.state.contrastMode}
                 highlighted={node.key === this.state.hoveredNodeId}

--- a/src/components/GraphNode/tags/_TagCamera.js
+++ b/src/components/GraphNode/tags/_TagCamera.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Rect = styled.rect.attrs({
+  fill: props =>
+    props.contrastMode
+      ? props.theme.colors.black
+      : props.theme.colors.purple800,
+  rx: 5,
+})``;
+
+const Circle = styled.circle.attrs({
+  stroke: props => props.theme.colors.white,
+  fill: props =>
+    props.contrastMode
+      ? props.theme.colors.black
+      : props.theme.colors.purple800,
+})``;
+
+export default class TagCamera extends React.Component {
+  render() {
+    return (
+      <g transform="translate(16, 6) scale(0.75)">
+        <Rect {...this.props} x="0" y="4" width="30" height="24" />
+        <Rect {...this.props} x="5" y="0" width="20" height="25" />
+        <Circle {...this.props} cx="15" cy="15" r="6" strokeWidth="4" />
+      </g>
+    );
+  }
+}


### PR DESCRIPTION
Prerequisite for https://github.com/weaveworks/scope/issues/3316.

![image](https://user-images.githubusercontent.com/1216874/45952222-96f86c80-c006-11e8-96ca-86912e098f1a.png)

The camera tag can be added to any node by passing `tag="camera"` to the component.
