### PR TITLE
Fix styles of Input component on Firefox

### DIFF
--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -36,7 +36,7 @@ const InputWrapper = styled.div`
 
   input {
     ${props => placeholder('color', props.theme.colors.gray600)};
-    ${props => placeholder('opacity', 1)};
+    ${placeholder('opacity', 1)};
 
     padding-right: ${props => (props.valid ? '12px' : '38px')};
     padding-left: 12px;

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -36,11 +36,14 @@ const InputWrapper = styled.div`
 
   input {
     ${props => placeholder('color', props.theme.colors.gray600)};
+    ${props => placeholder('opacity', 1)};
+
     padding-right: ${props => (props.valid ? '12px' : '38px')};
     padding-left: 12px;
     width: 100%;
     line-height: 36px;
     box-shadow: none;
+    background-color: ${props => props.theme.colors.white};
     border: 1px solid ${props => props.theme.colors.gray600};
     border-radius: ${props => props.theme.borderRadius.soft};
     height: 36px;

--- a/src/components/Input/__snapshots__/Input.test.js.snap
+++ b/src/components/Input/__snapshots__/Input.test.js.snap
@@ -29,6 +29,7 @@ exports[`<Input /> should render correctly 1`] = `
   width: 100%;
   line-height: 36px;
   box-shadow: none;
+  background-color: hsl(0,0%,100%);
   border: 1px solid hsl(0,0%,45%);
   border-radius: 2px;
   height: 36px;
@@ -49,6 +50,22 @@ exports[`<Input /> should render correctly 1`] = `
 
 .c1 input:-ms-input-placeholder {
   color: hsl(0,0%,45%);
+}
+
+.c1 input::-webkit-input-placeholder {
+  opacity: 1;
+}
+
+.c1 input::-moz-placeholder {
+  opacity: 1;
+}
+
+.c1 input:-moz-placeholder {
+  opacity: 1;
+}
+
+.c1 input:-ms-input-placeholder {
+  opacity: 1;
 }
 
 .c1 input:disabled {

--- a/src/components/Search/__snapshots__/Search.test.js.snap
+++ b/src/components/Search/__snapshots__/Search.test.js.snap
@@ -29,6 +29,7 @@ exports[`<Search /> snapshots renders a group of terms 1`] = `
   width: 100%;
   line-height: 36px;
   box-shadow: none;
+  background-color: hsl(0,0%,100%);
   border: 1px solid hsl(0,0%,45%);
   border-radius: 2px;
   height: 36px;
@@ -49,6 +50,22 @@ exports[`<Search /> snapshots renders a group of terms 1`] = `
 
 .c7 input:-ms-input-placeholder {
   color: hsl(0,0%,45%);
+}
+
+.c7 input::-webkit-input-placeholder {
+  opacity: 1;
+}
+
+.c7 input::-moz-placeholder {
+  opacity: 1;
+}
+
+.c7 input:-moz-placeholder {
+  opacity: 1;
+}
+
+.c7 input:-ms-input-placeholder {
+  opacity: 1;
 }
 
 .c7 input:disabled {
@@ -290,6 +307,7 @@ exports[`<Search /> snapshots renders a search string 1`] = `
   width: 100%;
   line-height: 36px;
   box-shadow: none;
+  background-color: hsl(0,0%,100%);
   border: 1px solid hsl(0,0%,45%);
   border-radius: 2px;
   height: 36px;
@@ -310,6 +328,22 @@ exports[`<Search /> snapshots renders a search string 1`] = `
 
 .c6 input:-ms-input-placeholder {
   color: hsl(0,0%,45%);
+}
+
+.c6 input::-webkit-input-placeholder {
+  opacity: 1;
+}
+
+.c6 input::-moz-placeholder {
+  opacity: 1;
+}
+
+.c6 input:-moz-placeholder {
+  opacity: 1;
+}
+
+.c6 input:-ms-input-placeholder {
+  opacity: 1;
 }
 
 .c6 input:disabled {
@@ -507,6 +541,7 @@ exports[`<Search /> snapshots renders empty 1`] = `
   width: 100%;
   line-height: 36px;
   box-shadow: none;
+  background-color: hsl(0,0%,100%);
   border: 1px solid hsl(0,0%,45%);
   border-radius: 2px;
   height: 36px;
@@ -527,6 +562,22 @@ exports[`<Search /> snapshots renders empty 1`] = `
 
 .c6 input:-ms-input-placeholder {
   color: hsl(0,0%,45%);
+}
+
+.c6 input::-webkit-input-placeholder {
+  opacity: 1;
+}
+
+.c6 input::-moz-placeholder {
+  opacity: 1;
+}
+
+.c6 input:-moz-placeholder {
+  opacity: 1;
+}
+
+.c6 input:-ms-input-placeholder {
+  opacity: 1;
 }
 
 .c6 input:disabled {
@@ -724,6 +775,7 @@ exports[`<Search /> snapshots renders filters 1`] = `
   width: 100%;
   line-height: 36px;
   box-shadow: none;
+  background-color: hsl(0,0%,100%);
   border: 1px solid hsl(0,0%,45%);
   border-radius: 2px;
   height: 36px;
@@ -744,6 +796,22 @@ exports[`<Search /> snapshots renders filters 1`] = `
 
 .c6 input:-ms-input-placeholder {
   color: hsl(0,0%,45%);
+}
+
+.c6 input::-webkit-input-placeholder {
+  opacity: 1;
+}
+
+.c6 input::-moz-placeholder {
+  opacity: 1;
+}
+
+.c6 input:-moz-placeholder {
+  opacity: 1;
+}
+
+.c6 input:-ms-input-placeholder {
+  opacity: 1;
 }
 
 .c6 input:disabled {


### PR DESCRIPTION
Makes Input component look the same on Firefox as on Chrome.

##### Before

![image](https://user-images.githubusercontent.com/1216874/46655377-c339ee80-cbab-11e8-91c3-2bf774a735f6.png)

##### After

![image](https://user-images.githubusercontent.com/1216874/46655396-d0ef7400-cbab-11e8-8775-ee891cc042d1.png)

In particular, this will address https://github.com/weaveworks/service-ui/issues/3291.
