### PR TITLE
Prom graph top value

### DIFF
--- a/src/components/PrometheusGraph/_AxesGrid.js
+++ b/src/components/PrometheusGraph/_AxesGrid.js
@@ -2,7 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { find, range, flatMap, last } from 'lodash';
+import { find, range, round, flatMap, last } from 'lodash';
 
 const AxesGridContainer = styled.div``;
 
@@ -107,7 +107,10 @@ function getValueTicks(metricUnits, minValue, maxValue) {
   /* eslint-enable no-restricted-properties */
 
   const step = find(steps, s => maxValue / s < 4);
-  return range(minValue, maxValue, step);
+
+  // lodash `range()` doesn't include the end value in the returned array so we
+  // add 1e-6 to move maxValue within the range
+  return range(round(minValue, 2), round(maxValue, 2) + 1e-6, step);
 }
 
 class AxesGrid extends React.PureComponent {


### PR DESCRIPTION
Depends on https://github.com/weaveworks/ui-components/pull/391, that needs to be merged first.

If the top value is a `step` away the show the maxValue on the axis

closes #392

**before**
![image](https://user-images.githubusercontent.com/1794071/47305529-a4af0b00-d621-11e8-9ab5-41d3b582c66d.png)


**after** (includes changes from https://github.com/weaveworks/ui-components/pull/391)
![image](https://user-images.githubusercontent.com/1794071/47305514-9660ef00-d621-11e8-875a-960408fd07c4.png)

