### PR TITLE
add max-height for dropdown panel

### DIFF
--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types';
 import { map, noop, find, flattenDepth, isArray } from 'lodash';
 
 const WIDTH = '256px';
-const HEIGHT = '36px';
+const HEIGHT_NUMBER = 36;
+const HEIGHT = `${HEIGHT_NUMBER}px`;
 
 const Item = styled.div`
   overflow: hidden;
@@ -30,6 +31,9 @@ const Popover = styled.div`
   box-shadow: ${props => props.theme.boxShadow.light};
   margin-top: 4px;
   width: ${props => props.width}px;
+  /* +10 to account for list top padding */
+  max-height: ${HEIGHT_NUMBER * 10 + 10}px;
+  overflow: auto;
   box-sizing: border-box;
   padding: 6px 0;
 `;

--- a/src/components/Dropdown/example.js
+++ b/src/components/Dropdown/example.js
@@ -6,20 +6,22 @@ import Button from '../Button';
 
 import Dropdown from '.';
 
-const items = [
+const generateItems = (hash = '') => [
   {
-    value: 'first-thing',
+    value: `first-thing${hash}`,
     label: 'First Thing',
   },
   {
-    value: 'second-thing',
+    value: `second-thing${hash}`,
     label: 'Second Thing',
   },
   {
-    value: 'third-thing',
+    value: `third-thing${hash}`,
     label: 'Super long thing, this should get truncated',
   },
 ];
+
+const items = generateItems();
 
 const groups = [
   [
@@ -82,7 +84,12 @@ export default class DropdownExample extends React.Component {
             <Example>
               <Info>Default dropdown</Info>
               <Dropdown
-                items={items}
+                items={[
+                  ...generateItems('a'),
+                  ...generateItems('b'),
+                  ...generateItems('c'),
+                  ...generateItems('d'),
+                ]}
                 value={this.state.selected}
                 onChange={this.handleChange}
               />
@@ -137,6 +144,7 @@ export default class DropdownExample extends React.Component {
             </Example>
           </Column>
         </Row>
+        <div style={{ height: '50px' }} />
       </Grid>
     );
   }


### PR DESCRIPTION
very long lists go off the bottom of the screen and so their values
cannot be accesssed. This commit sets a max-height of 10 items, and
then scroll.