### PR TITLE
only render labal if there is a label

### DIFF
--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -31,8 +31,8 @@ const InputWrapper = styled.div`
   position: relative;
   display: flex;
   align-items: center;
-  margin-top: 10px;
   height: 36px;
+  ${({ hasLabel }) => hasLabel && `margin-top: 10px`};
 
   input {
     ${props => placeholder('color', props.theme.colors.gray600)};
@@ -126,8 +126,8 @@ class Input extends React.Component {
 
     return (
       <div className={className}>
-        <label htmlFor={id}>{label}</label>
-        <InputWrapper valid={valid}>
+        {label && <label htmlFor={id}>{label}</label>}
+        <InputWrapper valid={valid} hasLabel={Boolean(label)}>
           {React.createElement(textarea ? 'textarea' : 'input', {
             ...omit(inputProps, 'autoSelectText', 'focus'),
             ref: elem => {

--- a/src/components/Input/Input.test.js
+++ b/src/components/Input/Input.test.js
@@ -60,6 +60,22 @@ describe('<Input />', () => {
     );
   });
 
+  it('should only render <label> if label prop is provided', () => {
+    props = {
+      valid: false,
+      message: 'Derp!',
+    };
+    wrapper = mount(withTheme(<Input {...props} />));
+
+    expect(wrapper.find('label').length).toBe(0);
+
+    wrapper = mount(
+      withTheme(<Input {...{ ...props, label: 'Woohoo, label time!' }} />)
+    );
+
+    expect(wrapper.find('label').length).toBe(1);
+  });
+
   it('should remove validation message from the DOM when hideValidationMessage=true', () => {
     props = {
       hideValidationMessage: true,

--- a/src/components/Input/__snapshots__/Input.test.js.snap
+++ b/src/components/Input/__snapshots__/Input.test.js.snap
@@ -19,8 +19,8 @@ exports[`<Input /> should render correctly 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-top: 10px;
   height: 36px;
+  margin-top: 10px;
 }
 
 .c1 input {
@@ -296,6 +296,7 @@ exports[`<Input /> should render correctly 1`] = `
           Hi
         </label>
         <Input__InputWrapper
+          hasLabel={true}
           valid={false}
         >
           <div

--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -84,10 +84,6 @@ const Styled = component => styled(component)`
     input:focus {
       outline: none;
     }
-
-    div {
-      margin: 0;
-    }
   }
 `;
 

--- a/src/components/Search/__snapshots__/Search.test.js.snap
+++ b/src/components/Search/__snapshots__/Search.test.js.snap
@@ -19,7 +19,6 @@ exports[`<Search /> snapshots renders a group of terms 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-top: 10px;
   height: 36px;
 }
 
@@ -201,10 +200,6 @@ exports[`<Search /> snapshots renders a group of terms 1`] = `
   outline: none;
 }
 
-.c0 .c5 div {
-  margin: 0;
-}
-
 <div
   className="c0"
 >
@@ -249,9 +244,7 @@ exports[`<Search /> snapshots renders a group of terms 1`] = `
     <div
       className="c5 c6"
     >
-      <label>
-        
-      </label>
+      
       <div
         className="c7"
       >
@@ -297,7 +290,6 @@ exports[`<Search /> snapshots renders a search string 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-top: 10px;
   height: 36px;
 }
 
@@ -462,10 +454,6 @@ exports[`<Search /> snapshots renders a search string 1`] = `
   outline: none;
 }
 
-.c0 .c4 div {
-  margin: 0;
-}
-
 <div
   className="c0"
 >
@@ -483,9 +471,7 @@ exports[`<Search /> snapshots renders a search string 1`] = `
     <div
       className="c4 c5"
     >
-      <label>
-        
-      </label>
+      
       <div
         className="c6"
       >
@@ -531,7 +517,6 @@ exports[`<Search /> snapshots renders empty 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-top: 10px;
   height: 36px;
 }
 
@@ -696,10 +681,6 @@ exports[`<Search /> snapshots renders empty 1`] = `
   outline: none;
 }
 
-.c0 .c4 div {
-  margin: 0;
-}
-
 <div
   className="c0"
 >
@@ -717,9 +698,7 @@ exports[`<Search /> snapshots renders empty 1`] = `
     <div
       className="c4 c5"
     >
-      <label>
-        
-      </label>
+      
       <div
         className="c6"
       >
@@ -765,7 +744,6 @@ exports[`<Search /> snapshots renders filters 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-top: 10px;
   height: 36px;
 }
 
@@ -982,10 +960,6 @@ exports[`<Search /> snapshots renders filters 1`] = `
   outline: none;
 }
 
-.c0 .c4 div {
-  margin: 0;
-}
-
 <div
   className="c0"
 >
@@ -1003,9 +977,7 @@ exports[`<Search /> snapshots renders filters 1`] = `
     <div
       className="c4 c5"
     >
-      <label>
-        
-      </label>
+      
       <div
         className="c6"
       >


### PR DESCRIPTION
This commit stops adding <label> to the DOM, when there is no
label prop provided. It also removes the margin - used to add space
between the label and input - when there is no label prop provided.

Removed margin reset that was no longer needed on Search component