### PR TITLE
[RFC] - add selectors for grabbing theme values

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { noop, omit } from 'lodash';
 
+import { borderRadius, boxShadow, fontSize } from '../../theme/selectors';
 import { fromAtoms } from '../../utils/theme';
 
 const StyledButton = styled('button')`
@@ -13,20 +14,18 @@ const StyledButton = styled('button')`
   border: 0;
   outline: none;
   box-shadow: ${props =>
-    props.styled.selected
-      ? props.theme.boxShadow.selected
-      : props.theme.boxShadow.light};
+    props.styled.selected ? boxShadow('selected') : boxShadow('light')};
 
   /* Color */
   background: ${fromAtoms('Button', 'styled.type', 'background')};
   color: ${fromAtoms('Button', 'styled.type', 'color')};
 
   /* Text */
-  font-size: ${props => props.theme.fontSizes.small};
+  font-size: ${fontSize('small')};
 
   /* Other */
   cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
-  border-radius: ${props => props.theme.borderRadius.soft};
+  border-radius: ${borderRadius('soft')};
 
   /* Pseudo-selectors */
   &:hover {

--- a/src/theme/selectors-test.js
+++ b/src/theme/selectors-test.js
@@ -1,0 +1,29 @@
+import { selector, color, fontSize } from './selectors';
+
+import theme from '.';
+
+const props = { theme };
+
+describe('ThemeSelectors', () => {
+  describe('fontSizes', () => {
+    it('should retrieve a fontSize', () => {
+      expect(typeof fontSize).toBe('function');
+      expect(fontSize('small')(props)).toBe(10);
+    });
+  });
+
+  describe('colors', () => {
+    it('should retrieve a color', () => {
+      expect(typeof color).toBe('function');
+      expect(color('grey200')(props)).toBe('#333');
+    });
+  });
+
+  describe('custom selector', () => {
+    it('should return a function ', () => {
+      const wongoBongo = selector('wongo.bongo');
+      expect(typeof wongoBongo).toBe('function');
+      expect(wongoBongo('jibberish')).toBe('boo');
+    });
+  });
+});

--- a/src/theme/selectors.js
+++ b/src/theme/selectors.js
@@ -1,0 +1,20 @@
+import { get, isObject } from 'lodash';
+
+// `selector()` allows you to create closures over as
+// many levels as you wish, each time returning another function.
+// This lets you compose selectors and when they are passed an object
+// finally select that value
+export const selector = (propsOrSelector, prevArgs = []) => {
+  if (isObject(propsOrSelector)) {
+    return get(propsOrSelector, prevArgs);
+  }
+
+  return value => selector(value, [...prevArgs, propsOrSelector]);
+};
+
+const themeSelector = selector('theme');
+
+export const boxShadow = themeSelector('boxShadow');
+export const borderRadius = themeSelector('borderRadius');
+export const color = themeSelector('colors');
+export const fontSize = themeSelector('fontSizes');


### PR DESCRIPTION
Composable selectors for grabbing values from props and specifically
theme in styled components.

Changes this:
`background-color: ${props => props.theme.colors.orange};`
into
`background-color: ${color('orange')}`


After implementing this I discovered the `fromAtoms` util and generally the `Atoms`
concept. @fbarl could you give me a breakdown about the thought behind that?