### PR TITLE
Remove unused fade-in-out mixin

### DIFF
--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -25,10 +25,6 @@
   transition: $args;
 }
 
-@mixin-fade-in-out {
-  @include transition(opacity, .2s, ease-in);
-}
-
 @mixin placeholder {
   &::-webkit-input-placeholder {@content}
   &:-moz-placeholder           {@content}


### PR DESCRIPTION
My VS code linter was complaining - not only is it unused but also malformed :)
