### PR TITLE
perf: only calculate time and value scales on new data

### DIFF
--- a/src/components/PrometheusGraph/_Chart.js
+++ b/src/components/PrometheusGraph/_Chart.js
@@ -36,17 +36,13 @@ const SeriesAreaChart = styled.path.attrs({
 
 class Chart extends React.PureComponent {
   handleResize = debounce(() => {
-    this.forceUpdate();
+    const { width, height } = this.getSvgBoundingRect();
+    this.props.onChartResize({ chartWidth: width, chartHeight: height });
   }, 50);
 
   componentDidMount() {
     this.handleResize();
     window.addEventListener('resize', this.handleResize);
-  }
-
-  componentDidUpdate() {
-    const { width, height } = this.getSvgBoundingRect();
-    this.props.onChartResize({ chartWidth: width, chartHeight: height });
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
This commit changes PrometheusGraph to only calculate timeScale and valueScale
when there is new data, not every render.
This solves performance bottleneck when 2000+ datapoints and 16graphs on a
page at once.

Profile CPU usage during a release:
Before
<img width="1129" alt="screenshot 2018-11-13 15 36 41" src="https://user-images.githubusercontent.com/1794071/48428798-aa50ca00-e763-11e8-8417-ba82f064220c.png">
After
<img width="970" alt="screenshot 2018-11-13 15 36 49" src="https://user-images.githubusercontent.com/1794071/48428797-aa50ca00-e763-11e8-8a9d-b01cdb51a02a.png">

Time spent in function on canary release page:
<img width="501" alt="screenshot 2018-11-13 14 52 57" src="https://user-images.githubusercontent.com/1794071/48428841-c2284e00-e763-11e8-8ee7-57980f2d7a68.png">

