### PR TITLE
feat(dropdown): adjusts max-height to show it can be scrolled

### DIFF
--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -31,8 +31,10 @@ const Popover = styled.div`
   box-shadow: ${props => props.theme.boxShadow.light};
   margin-top: 4px;
   width: ${props => props.width}px;
-  /* +10 to account for list top padding */
-  max-height: ${HEIGHT_NUMBER * 10 + 10}px;
+  /* +10 to account for list top padding.
+   * Multiply by an 0.5 to visually slice the last item in half to more clearly show that the
+   * dropdown can be scrolled. */
+  max-height: ${HEIGHT_NUMBER * 10.5 + 10}px;
   overflow: auto;
   box-sizing: border-box;
   padding: 6px 0;

--- a/src/components/Dropdown/example.js
+++ b/src/components/Dropdown/example.js
@@ -144,7 +144,7 @@ export default class DropdownExample extends React.Component {
             </Example>
           </Column>
         </Row>
-        <div style={{ height: '50px' }} />
+        <div style={{ height: '70px' }} />
       </Grid>
     );
   }


### PR DESCRIPTION
- Some OS's don't show scrollbars so we chop the last item in half.

Fixes #428