### PR TITLE
Standardise component padding and margins

### DIFF
--- a/src/components/Alert/Alert.js
+++ b/src/components/Alert/Alert.js
@@ -11,10 +11,10 @@ const StyledAlert = styled.div`
   background: ${fromAtoms('Alert', 'type', 'background')};
   border-radius: ${props => props.theme.borderRadius.soft};
   color: ${fromAtoms('Alert', 'type', 'color')};
-  margin: 8px 0 8px 0;
+  margin: ${spacing('xs')} 0 ${spacing('xs')} 0;
   min-height: 1em;
   opacity: ${props => (props.visible ? '1' : '0')};
-  padding: ${spacing('small')};
+  padding: ${spacing('base')};
   transition: opacity 0.2s linear;
 
   a {
@@ -32,7 +32,7 @@ const Content = styled.div`
 `;
 
 const Title = styled.div`
-  margin-bottom: 0.5em;
+  margin-bottom: ${spacing('xs')};
 `;
 
 const StyledText = styled(Text)`
@@ -41,13 +41,13 @@ const StyledText = styled(Text)`
 `;
 
 const Icon = styled.i`
-  margin-right: 0.5em;
+  margin-right: ${spacing('xs')};
 `;
 
 const CloseIcon = styled.i`
   cursor: pointer;
   display: ${props => (props.visible ? 'block' : 'none')};
-  margin-left: 1em;
+  margin-left: ${spacing('base')};
 `;
 
 const normaliseIconName = name =>

--- a/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -245,7 +245,7 @@ exports[`<Alert /> snapshots renders title if provided 1`] = `
 }
 
 .c2 {
-  margin-bottom: 0.5em;
+  margin-bottom: 8px;
 }
 
 .c3 {

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -3,14 +3,19 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { noop, omit } from 'lodash';
 
-import { borderRadius, boxShadow, fontSize } from '../../theme/selectors';
+import {
+  borderRadius,
+  boxShadow,
+  fontSize,
+  spacing,
+} from '../../theme/selectors';
 import { fromAtoms } from '../../utils/theme';
 
 const StyledButton = styled('button')`
   /* Display & Box Model */
   height: 36px;
   min-width: 90px;
-  padding: 0 12px;
+  padding: 0 ${spacing('small')};
   border: 0;
   outline: none;
   box-shadow: ${props =>

--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import styled, { keyframes } from 'styled-components';
 import { isFunction, isString, trim, noop } from 'lodash';
 
+import { spacing } from '../../theme/selectors';
+
 const scale = keyframes`
   0% {
     transform: scale(0)
@@ -19,7 +21,7 @@ const CopyNotice = styled.div`
   position: absolute;
   top: 0;
   right: 0;
-  padding: 10px 15px;
+  padding: ${spacing('xs')};
   ${props => props.isHovered && 'transition: opacity 300ms ease;'};
   border-radius: ${props => props.theme.borderRadius.soft};
   background-color: ${props => props.theme.colors.purple800};
@@ -56,18 +58,18 @@ const ScrollWrap = styled.div`
 const Content = styled.div`
   flex-grow: 1;
   color: ${props => props.theme.colors.purple50};
-  padding: 10px 15px;
+  padding: ${spacing('xs')} ${spacing('base')};
 `;
 
 const Pre = styled.pre`
-  margin: 10px 0;
+  margin: ${spacing('small')} 0;
   font-family: ${props => props.theme.fontFamilies.monospace};
   font-size: ${props => props.theme.fontSizes.small};
 `;
 
 const PaddedLine = styled.div`
   &:not(:last-child) {
-    padding-bottom: 8px;
+    padding-bottom: ${spacing('xs')};
   }
 
   /* required to make jsx children work with adding '\n' in multiLine */

--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { map, orderBy, noop, get, first, partialRight } from 'lodash';
 import { transparentize } from 'polished';
+import { spacing } from '../../theme/selectors';
 
 import Header from './_Header';
 
@@ -16,7 +17,7 @@ const Table = styled.table`
   table-layout: fixed;
 
   td {
-    padding: 10px 8px;
+    padding: ${spacing('small')} ${spacing('xs')};
     vertical-align: top;
     border-left: 1px solid ${borderColor};
   }

--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { map, orderBy, noop, get, first, partialRight } from 'lodash';
 import { transparentize } from 'polished';
+
 import { spacing } from '../../theme/selectors';
 
 import Header from './_Header';

--- a/src/components/DataTable/__snapshots__/DataTable.test.js.snap
+++ b/src/components/DataTable/__snapshots__/DataTable.test.js.snap
@@ -21,7 +21,7 @@ exports[`DataTable snapshots renders an element instead of a label 1`] = `
 }
 
 .c0 td {
-  padding: 10px 8px;
+  padding: 12px 8px;
   vertical-align: top;
   border-left: 1px solid rgba(224,224,235,0.4);
 }
@@ -133,7 +133,7 @@ exports[`DataTable snapshots renders column widths 1`] = `
 }
 
 .c0 td {
-  padding: 10px 8px;
+  padding: 12px 8px;
   vertical-align: top;
   border-left: 1px solid rgba(224,224,235,0.4);
 }
@@ -229,7 +229,7 @@ exports[`DataTable snapshots renders extra headers 1`] = `
 }
 
 .c0 td {
-  padding: 10px 8px;
+  padding: 12px 8px;
   vertical-align: top;
   border-left: 1px solid rgba(224,224,235,0.4);
 }
@@ -335,7 +335,7 @@ exports[`DataTable snapshots renders nested rows 1`] = `
 }
 
 .c0 td {
-  padding: 10px 8px;
+  padding: 12px 8px;
   vertical-align: top;
   border-left: 1px solid rgba(224,224,235,0.4);
 }
@@ -461,7 +461,7 @@ exports[`DataTable snapshots renders rows 1`] = `
 }
 
 .c0 td {
-  padding: 10px 8px;
+  padding: 12px 8px;
   vertical-align: top;
   border-left: 1px solid rgba(224,224,235,0.4);
 }
@@ -557,7 +557,7 @@ exports[`DataTable snapshots sorts fields by a give order 1`] = `
 }
 
 .c0 td {
-  padding: 10px 8px;
+  padding: 12px 8px;
   vertical-align: top;
   border-left: 1px solid rgba(224,224,235,0.4);
 }
@@ -653,7 +653,7 @@ exports[`DataTable snapshots sorts rows by a field 1`] = `
 }
 
 .c0 td {
-  padding: 10px 8px;
+  padding: 12px 8px;
   vertical-align: top;
   border-left: 1px solid rgba(224,224,235,0.4);
 }

--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { noop, isEmpty } from 'lodash';
-
+import { spacing } from '../../theme/selectors';
 import Button from '../Button';
 
 const Wrapper = styled.div`
@@ -46,7 +46,7 @@ const Window = styled.div`
   width: ${props => props.width};
   margin: 0 auto;
   max-width: 768px;
-  padding: 15px 20px 20px;
+  padding: ${spacing('base')} ${spacing('medium')} ${spacing('medium')};
   position: relative;
 `;
 
@@ -65,8 +65,8 @@ const ButtonClose = styled.button`
   border: 0;
   background: transparent;
   cursor: pointer;
-  margin-right: -5px;
-  padding: 5px;
+  margin-right: -${spacing('xxs')};
+  padding: ${spacing('xxs')};
   outline: 0;
 
   &:hover {
@@ -81,7 +81,7 @@ const Actions = styled.div`
   min-height: 36px;
 
   button {
-    margin-left: 10px;
+    margin-left: ${spacing('small')};
   }
 `;
 

--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -2,8 +2,9 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { noop, isEmpty } from 'lodash';
-import { spacing } from '../../theme/selectors';
+
 import Button from '../Button';
+import { spacing } from '../../theme/selectors';
 
 const Wrapper = styled.div`
   z-index: ${props => props.theme.layers.modal};

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { map, noop, find, flattenDepth, isArray } from 'lodash';
+import { spacing } from '../../theme/selectors';
 
 const WIDTH = '256px';
 const HEIGHT_NUMBER = 36;
@@ -11,10 +12,9 @@ const Item = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  padding-right: 28px;
-  padding-left: 12px;
+  padding-right: ${spacing('medium')};
+  padding-left: ${spacing('small')};
   cursor: pointer;
-
   ${props =>
     props.disabled &&
     `
@@ -37,7 +37,7 @@ const Popover = styled.div`
   max-height: ${HEIGHT_NUMBER * 10.5 + 10}px;
   overflow: auto;
   box-sizing: border-box;
-  padding: 6px 0;
+  padding: ${spacing('xxs')} 0;
 `;
 
 const Overlay = styled.div`
@@ -54,7 +54,6 @@ const ItemWrapper = styled(Item)`
   color: ${props =>
     props.selected ? props.theme.colors.blue400 : props.theme.textColor};
   min-height: ${HEIGHT};
-
   &:hover {
     background-color: ${props => props.theme.colors.gray50};
   }
@@ -72,15 +71,12 @@ const SelectedItem = styled(Item)`
   background-color: ${props => props.theme.colors.white};
   border: 1px solid ${props => props.theme.colors.gray600};
   display: flex;
-
   ${Item} {
     padding: 0;
   }
-
   div:last-child {
     margin-left: auto;
   }
-
   ${props =>
     props.disabled &&
     `

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { map, noop, find, flattenDepth, isArray } from 'lodash';
+
 import { spacing } from '../../theme/selectors';
 
 const WIDTH = '256px';

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -5,7 +5,7 @@ exports[`<Dropdown /> snapshots renders a placeholder 1`] = `
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  padding-right: 28px;
+  padding-right: 24px;
   padding-left: 12px;
   cursor: pointer;
 }
@@ -74,12 +74,21 @@ exports[`<Dropdown /> snapshots renders default 1`] = `
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  padding-right: 28px;
+  padding-right: 24px;
   padding-left: 12px;
   cursor: pointer;
 }
 
 .c1 {
+<<<<<<< HEAD
+=======
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-right: 24px;
+  padding-left: 12px;
+  cursor: pointer;
+>>>>>>> feat: replace component margins and padding with theme spacing
   height: 36px;
   box-sizing: border-box;
   border-radius: 2px;

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -80,15 +80,6 @@ exports[`<Dropdown /> snapshots renders default 1`] = `
 }
 
 .c1 {
-<<<<<<< HEAD
-=======
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  padding-right: 24px;
-  padding-left: 12px;
-  cursor: pointer;
->>>>>>> feat: replace component margins and padding with theme spacing
   height: 36px;
   box-sizing: border-box;
   border-radius: 2px;

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { omit, noop } from 'lodash';
 import styled, { css } from 'styled-components';
+import { spacing } from '../../theme/selectors';
 
 const placeholder = (property, content) => css`
   &::-webkit-input-placeholder {
@@ -31,14 +32,16 @@ const InputWrapper = styled.div`
   display: flex;
   align-items: center;
   height: 36px;
-  ${({ hasLabel }) => hasLabel && `margin-top: 10px`};
+  margin-top: ${spacing('xs')};
+  ${({ hasLabel }) => !hasLabel && `margin-top: 0px`};
 
   input {
     ${props => placeholder('color', props.theme.colors.gray600)};
     ${placeholder('opacity', 1)};
 
-    padding-right: ${props => (props.valid ? '12px' : '38px')};
-    padding-left: 12px;
+    padding-right: ${props =>
+      props.valid ? spacing('small') : spacing('large')};
+    padding-left: ${spacing('small')};
     width: 100%;
     line-height: 36px;
     box-shadow: none;
@@ -56,13 +59,13 @@ const InputWrapper = styled.div`
 `;
 
 const StyledInput = component => styled(component)`
-  padding: 8px;
+  padding: ${spacing('xs')};
 `;
 
 const ValidationMessage = styled.span`
   display: ${props => (props.remove || !props.visible ? 'none' : 'block')};
-  padding-left: 8px;
-  margin-top: 8px;
+  padding-left: ${spacing('xs')};
+  margin-top: ${spacing('xs')};
   font-size: ${props => props.theme.fontSizes.small};
   text-align: left;
   color: ${props => (props.valid ? 'inherit' : props.theme.colors.orange600)};

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { omit, noop } from 'lodash';
 import styled, { css } from 'styled-components';
+
 import { spacing } from '../../theme/selectors';
 
 const placeholder = (property, content) => css`

--- a/src/components/Input/__snapshots__/Input.test.js.snap
+++ b/src/components/Input/__snapshots__/Input.test.js.snap
@@ -19,11 +19,11 @@ exports[`<Input /> should render correctly 1`] = `
   -ms-flex-align: center;
   align-items: center;
   height: 36px;
-  margin-top: 10px;
+  margin-top: 8px;
 }
 
 .c1 input {
-  padding-right: 38px;
+  padding-right: 32px;
   padding-left: 12px;
   width: 100%;
   line-height: 36px;
@@ -267,13 +267,15 @@ exports[`<Input /> should render correctly 1`] = `
       },
       "overlayIconSize": "300px",
       "spacing": Object {
-        "base": "24px",
-        "large": "48px",
+        "base": "16px",
+        "large": "32px",
+        "medium": "24px",
         "none": "0",
-        "small": "16px",
-        "xl": "64px",
+        "small": "12px",
+        "xl": "48px",
         "xs": "8px",
-        "xss": "4px",
+        "xxl": "64px",
+        "xxs": "4px",
       },
       "textColor": "hsl(0, 0%, 10%)",
     }

--- a/src/components/ListItem/ListItem.js
+++ b/src/components/ListItem/ListItem.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+
 import { spacing } from '../../theme/selectors';
 
 const Container = styled.div`

--- a/src/components/ListItem/ListItem.js
+++ b/src/components/ListItem/ListItem.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { spacing } from '../../theme/selectors';
 
 const Container = styled.div`
   display: flex;
   position: relative;
-  padding: 12px 16px;
+  padding: ${spacing('small')} ${spacing('base')};
 
   ${props =>
     props.active &&
@@ -17,7 +18,7 @@ const Container = styled.div`
 const Link = Container.withComponent('a');
 
 const Icon = styled.span`
-  margin-right: 12px;
+  margin-right: ${spacing('small')};
 `;
 
 const Content = styled.div`

--- a/src/components/Menu/MenuItem.js
+++ b/src/components/Menu/MenuItem.js
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import styled from 'styled-components';
 import { noop } from 'lodash';
+import { spacing } from '../../theme/selectors';
 
 const Item = styled.div`
   border-radius: ${props => props.theme.borderRadius.soft};
   display: block;
   min-height: 40px;
   line-height: 40px;
-  padding-left: 20px;
+  padding-left: ${spacing('medium')};
 
   &:hover {
     transition: color, 0.3s, ease;
@@ -22,7 +23,7 @@ const Item = styled.div`
     props.isSubItem &&
     `
     font-size: 14px;
-    padding-left: 40px;
+    padding-left: ${props.theme.spacing.xl};
     line-height: 30px;
     min-height: 30px;
   `};

--- a/src/components/Menu/MenuItem.js
+++ b/src/components/Menu/MenuItem.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import styled from 'styled-components';
 import { noop } from 'lodash';
+
 import { spacing } from '../../theme/selectors';
 
 const Item = styled.div`

--- a/src/components/PrometheusGraph/PrometheusGraph.js
+++ b/src/components/PrometheusGraph/PrometheusGraph.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { spacing } from '../../theme/selectors';
 import {
   first,
   flatten,
@@ -34,6 +33,7 @@ import {
 import { stack } from 'd3-shape';
 
 import theme from '../../theme';
+import { spacing } from '../../theme/selectors';
 
 import Chart from './_Chart';
 import AxesGrid from './_AxesGrid';

--- a/src/components/PrometheusGraph/PrometheusGraph.js
+++ b/src/components/PrometheusGraph/PrometheusGraph.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { spacing } from '../../theme/selectors';
 import {
   first,
   flatten,
@@ -94,13 +95,13 @@ function getColorTheme({ colorTheme, showStacked }) {
 
 const GraphWrapper = styled.div`
   position: relative;
-  padding-left: 45px;
+  padding-left: ${spacing('xl')};
 `;
 
 const GraphContainer = styled.div`
   position: relative;
   min-height: 170px;
-  margin-bottom: 20px;
+  margin-bottom: ${spacing('medium')};
   opacity: ${props => (props.loading ? 0.35 : 1)};
 `;
 

--- a/src/components/ResourceDial/ResourceDial.js
+++ b/src/components/ResourceDial/ResourceDial.js
@@ -6,9 +6,9 @@ import styled from 'styled-components';
 import { format } from 'd3-format';
 import { arc } from 'd3-shape';
 import { isEmpty, isFinite } from 'lodash';
-import { spacing } from '../../theme/selectors';
 
 import theme from '../../theme';
+import { spacing } from '../../theme/selectors';
 
 const DIAL_RADIUS_PX = 85;
 const DIAL_BORDER_PX = 8;

--- a/src/components/ResourceDial/ResourceDial.js
+++ b/src/components/ResourceDial/ResourceDial.js
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { format } from 'd3-format';
 import { arc } from 'd3-shape';
 import { isEmpty, isFinite } from 'lodash';
+import { spacing } from '../../theme/selectors';
 
 import theme from '../../theme';
 
@@ -80,7 +81,7 @@ const DialValueContainer = styled.div`
 
 const DialValue = styled.div`
   font-size: ${props => props.theme.fontSizes.huge};
-  margin: 0 4px;
+  margin: 0 ${spacing('xxs')};
 `;
 
 const PercentageSign = styled.div`

--- a/src/components/Search/__snapshots__/Search.test.js.snap
+++ b/src/components/Search/__snapshots__/Search.test.js.snap
@@ -19,6 +19,8 @@ exports[`<Search /> snapshots renders a group of terms 1`] = `
   -ms-flex-align: center;
   align-items: center;
   height: 36px;
+  margin-top: 8px;
+  margin-top: 0px;
 }
 
 .c7 input {
@@ -251,7 +253,7 @@ exports[`<Search /> snapshots renders a group of terms 1`] = `
     <div
       className="c5 c6"
     >
-      
+
       <div
         className="c7"
       >
@@ -271,7 +273,7 @@ exports[`<Search /> snapshots renders a group of terms 1`] = `
       <span
         className="c9"
       >
-        
+
       </span>
     </div>
   </div>
@@ -297,6 +299,8 @@ exports[`<Search /> snapshots renders a search string 1`] = `
   -ms-flex-align: center;
   align-items: center;
   height: 36px;
+  margin-top: 8px;
+  margin-top: 0px;
 }
 
 .c6 input {
@@ -481,7 +485,7 @@ exports[`<Search /> snapshots renders a search string 1`] = `
     <div
       className="c4 c5"
     >
-      
+
       <div
         className="c6"
       >
@@ -501,7 +505,7 @@ exports[`<Search /> snapshots renders a search string 1`] = `
       <span
         className="c8"
       >
-        
+
       </span>
     </div>
   </div>
@@ -527,6 +531,8 @@ exports[`<Search /> snapshots renders empty 1`] = `
   -ms-flex-align: center;
   align-items: center;
   height: 36px;
+  margin-top: 8px;
+  margin-top: 0px;
 }
 
 .c6 input {
@@ -711,7 +717,7 @@ exports[`<Search /> snapshots renders empty 1`] = `
     <div
       className="c4 c5"
     >
-      
+
       <div
         className="c6"
       >
@@ -731,7 +737,7 @@ exports[`<Search /> snapshots renders empty 1`] = `
       <span
         className="c8"
       >
-        
+
       </span>
     </div>
   </div>
@@ -757,6 +763,8 @@ exports[`<Search /> snapshots renders filters 1`] = `
   -ms-flex-align: center;
   align-items: center;
   height: 36px;
+  margin-top: 8px;
+  margin-top: 0px;
 }
 
 .c6 input {
@@ -842,7 +850,7 @@ exports[`<Search /> snapshots renders filters 1`] = `
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  padding-right: 28px;
+  padding-right: 24px;
   padding-left: 12px;
   cursor: pointer;
 }
@@ -987,7 +995,7 @@ exports[`<Search /> snapshots renders filters 1`] = `
     <div
       className="c4 c5"
     >
-      
+
       <div
         className="c6"
       >
@@ -1007,7 +1015,7 @@ exports[`<Search /> snapshots renders filters 1`] = `
       <span
         className="c8"
       >
-        
+
       </span>
     </div>
   </div>

--- a/src/components/Search/__snapshots__/Search.test.js.snap
+++ b/src/components/Search/__snapshots__/Search.test.js.snap
@@ -253,7 +253,7 @@ exports[`<Search /> snapshots renders a group of terms 1`] = `
     <div
       className="c5 c6"
     >
-
+      
       <div
         className="c7"
       >
@@ -273,7 +273,7 @@ exports[`<Search /> snapshots renders a group of terms 1`] = `
       <span
         className="c9"
       >
-
+        
       </span>
     </div>
   </div>
@@ -485,7 +485,7 @@ exports[`<Search /> snapshots renders a search string 1`] = `
     <div
       className="c4 c5"
     >
-
+      
       <div
         className="c6"
       >
@@ -505,7 +505,7 @@ exports[`<Search /> snapshots renders a search string 1`] = `
       <span
         className="c8"
       >
-
+        
       </span>
     </div>
   </div>
@@ -717,7 +717,7 @@ exports[`<Search /> snapshots renders empty 1`] = `
     <div
       className="c4 c5"
     >
-
+      
       <div
         className="c6"
       >
@@ -737,7 +737,7 @@ exports[`<Search /> snapshots renders empty 1`] = `
       <span
         className="c8"
       >
-
+        
       </span>
     </div>
   </div>
@@ -995,7 +995,7 @@ exports[`<Search /> snapshots renders filters 1`] = `
     <div
       className="c4 c5"
     >
-
+      
       <div
         className="c6"
       >
@@ -1015,7 +1015,7 @@ exports[`<Search /> snapshots renders filters 1`] = `
       <span
         className="c8"
       >
-
+        
       </span>
     </div>
   </div>

--- a/src/components/TabSelect/TabSelect.js
+++ b/src/components/TabSelect/TabSelect.js
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import { pick, map, find, get } from 'lodash';
 import PropTypes from 'prop-types';
-import { spacing } from '../../theme/selectors';
 
 import Tab from './Tab';
 import TabButton from './_TabButton';

--- a/src/components/TabSelect/TabSelect.js
+++ b/src/components/TabSelect/TabSelect.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { pick, map, find, get } from 'lodash';
 import PropTypes from 'prop-types';
+import { spacing } from '../../theme/selectors';
 
 import Tab from './Tab';
 import TabButton from './_TabButton';
@@ -20,7 +21,8 @@ const bordersOnlyTop = props => `
 `;
 
 const TabContent = styled.div`
-  padding: ${props => (props.small ? '10px' : '20px')};
+  padding: ${props =>
+    props.small ? props.theme.spacing.small : props.theme.spacing.medium};
   background-color: ${props =>
     props.secondary ? 'transparent' : props.theme.colors.white};
 

--- a/src/components/TabSelect/_TabButton.js
+++ b/src/components/TabSelect/_TabButton.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+
 import { spacing } from '../../theme/selectors';
 
 const TabName = styled.span``;

--- a/src/components/TabSelect/_TabButton.js
+++ b/src/components/TabSelect/_TabButton.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { spacing } from '../../theme/selectors';
 
 const TabName = styled.span``;
 
@@ -14,8 +15,11 @@ const getBgColor = (selected, secondary, theme) => {
 const Styled = component => styled(component)`
   cursor: pointer;
   margin-bottom: -1px;
-  margin-right: 5px;
-  padding: ${props => (props.small ? '5px 10px' : '10px 20px')};
+  margin-right: ${spacing('xxs')};
+  padding-top: ${props => (props.small ? spacing('xs') : spacing('xs'))};
+  padding-bottom: ${props => (props.small ? spacing('xs') : spacing('xs'))};
+  padding-left: ${props => (props.small ? spacing('small') : spacing('base'))};
+  padding-right: ${props => (props.small ? spacing('small') : spacing('base'))};
   font-size: ${props =>
     props.small ? props.theme.fontSizes.normal : props.theme.fontSizes.large};
   outline: 0;

--- a/src/components/TabSelect/__snapshots__/TabSelect.test.js.snap
+++ b/src/components/TabSelect/__snapshots__/TabSelect.test.js.snap
@@ -4,8 +4,11 @@ exports[`<Tab Select /> snapshots renders 1`] = `
 .c0 {
   cursor: pointer;
   margin-bottom: -1px;
-  margin-right: 5px;
-  padding: 10px 20px;
+  margin-right: 4px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
   font-size: 22px;
   outline: 0;
   background-color: hsl(0,0%,100%);
@@ -23,8 +26,11 @@ exports[`<Tab Select /> snapshots renders 1`] = `
 .c2 {
   cursor: pointer;
   margin-bottom: -1px;
-  margin-right: 5px;
-  padding: 10px 20px;
+  margin-right: 4px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
   font-size: 22px;
   outline: 0;
   background-color: hsl(0,0%,96%);
@@ -39,7 +45,7 @@ exports[`<Tab Select /> snapshots renders 1`] = `
 }
 
 .c3 {
-  padding: 20px;
+  padding: 24px;
   background-color: hsl(0,0%,100%);
   border-top-right-radius: 2px;
   border-bottom-right-radius: 2px;
@@ -100,8 +106,11 @@ exports[`<Tab Select /> snapshots renders with a selectedTab 1`] = `
 .c2 {
   cursor: pointer;
   margin-bottom: -1px;
-  margin-right: 5px;
-  padding: 10px 20px;
+  margin-right: 4px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
   font-size: 22px;
   outline: 0;
   background-color: hsl(0,0%,100%);
@@ -119,8 +128,11 @@ exports[`<Tab Select /> snapshots renders with a selectedTab 1`] = `
 .c0 {
   cursor: pointer;
   margin-bottom: -1px;
-  margin-right: 5px;
-  padding: 10px 20px;
+  margin-right: 4px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
   font-size: 22px;
   outline: 0;
   background-color: hsl(0,0%,96%);
@@ -135,7 +147,7 @@ exports[`<Tab Select /> snapshots renders with a selectedTab 1`] = `
 }
 
 .c3 {
-  padding: 20px;
+  padding: 24px;
   background-color: hsl(0,0%,100%);
   border-top-right-radius: 2px;
   border-bottom-right-radius: 2px;

--- a/src/components/TimeTravel/TimeTravel.js
+++ b/src/components/TimeTravel/TimeTravel.js
@@ -3,8 +3,8 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { clamp, find, debounce, noop } from 'lodash';
-import { spacing } from '../../theme/selectors';
 
+import { spacing } from '../../theme/selectors';
 import { formattedTimestamp, getTimeScale } from '../../utils/timeline';
 
 import { MAX_TICK_SPACING_PX } from './_TimelinePeriodLabels';

--- a/src/components/TimeTravel/TimeTravel.js
+++ b/src/components/TimeTravel/TimeTravel.js
@@ -3,6 +3,7 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { clamp, find, debounce, noop } from 'lodash';
+import { spacing } from '../../theme/selectors';
 
 import { formattedTimestamp, getTimeScale } from '../../utils/timeline';
 
@@ -28,7 +29,7 @@ const TimelineBar = styled.div`
 const TimeControlsWrapper = styled.div`
   display: flex;
   justify-content: center;
-  margin: 8px 0 25px;
+  margin: ${spacing('xs')} 0 ${spacing('medium')};
 `;
 
 const TimeControlsContainer = styled.div`

--- a/src/theme/spacings.js
+++ b/src/theme/spacings.js
@@ -2,12 +2,14 @@ import { forEach } from 'lodash';
 
 export const spacing = {
   none: '0',
-  xss: '4px',
+  xxs: '4px',
   xs: '8px',
-  small: '16px',
-  base: '24px',
-  large: '48px',
-  xl: '64px',
+  small: '12px',
+  base: '16px',
+  medium: '24px',
+  large: '32px',
+  xl: '48px',
+  xxl: '64px',
 };
 
 // Collects all theme spacing vars as SCSS vars.

--- a/src/utils/example.js
+++ b/src/utils/example.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+
 import { spacing } from '../theme/selectors';
 
 export const Example = styled.div`

--- a/src/utils/example.js
+++ b/src/utils/example.js
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
+import { spacing } from '../theme/selectors';
 
 export const Example = styled.div`
-  margin-bottom: 30px;
+  margin-bottom: ${spacing('large')};
 `;
 
 export const Info = styled.h4`
   color: ${props => props.theme.colors.gray600};
   font-size: ${props => props.theme.fontSizes.normal};
-  margin-bottom: 13px;
+  margin-bottom: ${spacing('small')};
 `;


### PR DESCRIPTION
Continues work after #400 

Here I've corrected #425 to a `16px` base, a [more appropriate model](https://twitter.com/adamwathan/status/1063492067916009473) coming out of discussion with @foot : 
![dsjh6wxuwaafslu](https://user-images.githubusercontent.com/92439/49094080-ae9ddc80-f265-11e8-8188-ca4090047157.jpg)

Pixel alignment tweaks for symbols and icons will be ignored by this system.
Still to be addressed : 
- Standardising line heights throughout components to match spacing
- Standardise width and height of components?
- Grid component
- In depth breakdown of TimeTravel component
- Scaling components like DotSpinner

I will create new issues for these accordingly.