### PR TITLE
fix: cve-2018-16487

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "@fortawesome/fontawesome-free": "^5.0.0",
-    "lodash": "^4.0.0",
+    "lodash": "^4.17.11",
     "moment": "^2.0.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
@@ -114,7 +114,7 @@
     "jest": "23.6.0",
     "jest-styled-components": "6.2.1",
     "less": "2.7.2",
-    "lodash": "4.17.10",
+    "lodash": "4.17.11",
     "marked": "0.3.12",
     "moment": "2.21.0",
     "node-sass": "4.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5893,13 +5893,13 @@ lodash.upperfirst@4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
 
-lodash@4.17.10, lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.10:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-
-lodash@^4.13.1, lodash@^4.17.3, lodash@^4.2.1:
+lodash@4.17.11, lodash@^4.13.1, lodash@^4.17.3, lodash@^4.2.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+
+lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.10:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 log-symbols@^2.0.0:
   version "2.2.0"


### PR DESCRIPTION
fix: update lodash >4.17.11 to address security vulnerability modifying
`Object.prototype`

* nvd.nist.gov/vuln/detail/CVE-2018-16487
* hackerone.com/reports/380873