### PR TITLE
Demo page aesthetic improvements

### DIFF
--- a/docs/css/demo.scss
+++ b/docs/css/demo.scss
@@ -1,6 +1,6 @@
-@import "../../src/styles/index.scss";
-@import "markdown.css";
-@import "syntax.css";
+@import '../../src/styles/index.scss';
+@import 'markdown.css';
+@import 'syntax.css';
 @import url('https://fonts.googleapis.com/css?family=Roboto');
 
 @font-face {
@@ -75,9 +75,8 @@ a {
 }
 
 .header {
-  border-bottom-width: 1px;
-  box-shadow: 0 4px 2px -2px rgba(0,0,0,.16);
   border-bottom: 1px solid #aaa;
+  border-bottom-width: 1px;
   width: 100%;
   overflow: hidden;
 
@@ -92,7 +91,7 @@ a {
 
   .logo {
     margin: 0;
-    padding: 0;
+    padding: 8px 0 0 8px;
     height: 50px;
     width: 200px;
   }
@@ -115,9 +114,9 @@ a:-webkit-any-link {
 }
 
 .big-nav-button {
-  @include material-shadow(heavy);
-  border-radius: 10px;
-  border: 1px solid #8383ac;
+  background-color: #ffffff;
+  box-shadow: 0 1px 3px #c7c7c7, 0 1px 2px #c7c7c7;
+  border-radius: 2px;
   display: block;
   height: 250px;
   margin-top: 100px;
@@ -127,6 +126,7 @@ a:-webkit-any-link {
 
   &:hover {
     cursor: pointer;
+    box-shadow: 0 1px 10px #ccc, 0 1px 8px #ccc;
     background-color: #3c3c5b;
     color: #f5f4f4;
     path,


### PR DESCRIPTION
Related to #460, some small modernisations to the look of the landing page of our demo page.

<img width="1440" alt="screenshot 2019-02-26 at 17 19 34" src="https://user-images.githubusercontent.com/92439/53443555-b8f97f00-39ea-11e9-877b-f0b6cea8c3d2.png">

