### PR TITLE
workaround for dropdown item label title `[object Object]`

### DIFF
--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -228,7 +228,9 @@ class Dropdown extends React.Component {
                       this.handleChange(ev, item.value, item.label)
                     }
                     selected={item.value === value}
-                    title={item && typeof item.label === "string" ? item.label : ""}
+                    title={
+                      item && typeof item.label === 'string' ? item.label : ''
+                    }
                   >
                     {item.label}
                   </ItemWrapper>

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -228,7 +228,7 @@ class Dropdown extends React.Component {
                       this.handleChange(ev, item.value, item.label)
                     }
                     selected={item.value === value}
-                    title={item && item.label}
+                    title={item && typeof item.label === "string" ? item.label : ""}
                   >
                     {item.label}
                   </ItemWrapper>


### PR DESCRIPTION
![Screenshot_20190322_123747](https://user-images.githubusercontent.com/15232461/54840565-adc10880-4ca3-11e9-867d-d57d77a0fcdb.png)


The above UI bug can happen in a situation where the label passed in is an object since objects are truthy in javascript.  Ideally, Flow should catch this kind of problem but since it doesn't (from what I can tell the type gets lost as it goes through the `lodash/find` on line 200), a type check here will work for now.