### PR TITLE
Refine dotted GraphNode shapes

### DIFF
--- a/src/components/GraphNode/shapes/_ShapeDottedCylinder.js
+++ b/src/components/GraphNode/shapes/_ShapeDottedCylinder.js
@@ -13,7 +13,7 @@ const UNIT_CYLINDER_PATH =
 
 const renderTemplate = (attrs, { allowStroke = true } = {}) =>
   allowStroke ? (
-    <path d={UNIT_CYLINDER_PATH} strokeDasharray="0.1, 0.05" {...attrs} />
+    <path d={UNIT_CYLINDER_PATH} strokeDasharray="0.4, 0.2" {...attrs} />
   ) : (
     <path d={UNIT_CYLINDER_PATH} {...attrs} />
   );

--- a/src/components/GraphNode/shapes/_ShapeDottedTriangle.js
+++ b/src/components/GraphNode/shapes/_ShapeDottedTriangle.js
@@ -4,7 +4,7 @@ import Shape, { curvedUnitPolygonPath } from './_Shape';
 
 const renderTemplate = (attrs, { allowStroke = true } = {}) =>
   allowStroke ? (
-    <path d={curvedUnitPolygonPath(3)} strokeDasharray="0.1, 0.05" {...attrs} />
+    <path d={curvedUnitPolygonPath(3)} strokeDasharray="0.4, 0.2" {...attrs} />
   ) : (
     <path d={curvedUnitPolygonPath(3)} {...attrs} />
   );


### PR DESCRIPTION
Currently the shapes look rather fuzzy,
<img width="1439" alt="Screenshot 2019-05-20 at 15 41 15" src="https://user-images.githubusercontent.com/92439/58026244-52ca5700-7b16-11e9-9a2c-fd6402f97506.png">

so you could say that I made them dashed, rather than dotted.
<img width="1442" alt="Screenshot 2019-05-20 at 15 40 25" src="https://user-images.githubusercontent.com/92439/58026310-768d9d00-7b16-11e9-8888-f90e7aa04648.png">

This is work towards #475 