### PR TITLE
Larger text in search component

### DIFF
--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -41,7 +41,7 @@ const Styled = component => styled(component)`
   props.theme.colors[props.disabled ? 'gray50' : 'white']};
   border: 1px solid ${props => props.theme.colors.purple100};
   border-radius: ${props => props.theme.borderRadius.soft};
-  font-size: ${props => props.theme.fontSizes.small};
+  font-size: ${props => props.theme.fontSizes.normal};
   align-items: center;
 
   div,

--- a/src/components/Search/__snapshots__/Search.test.js.snap
+++ b/src/components/Search/__snapshots__/Search.test.js.snap
@@ -163,7 +163,7 @@ exports[`<Search /> snapshots renders a group of terms 1`] = `
   background-color: hsl(0,0%,100%);
   border: 1px solid hsl(240,20%,90%);
   border-radius: 2px;
-  font-size: 14px;
+  font-size: 16px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -422,7 +422,7 @@ exports[`<Search /> snapshots renders a search string 1`] = `
   background-color: hsl(0,0%,100%);
   border: 1px solid hsl(240,20%,90%);
   border-radius: 2px;
-  font-size: 14px;
+  font-size: 16px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -654,7 +654,7 @@ exports[`<Search /> snapshots renders empty 1`] = `
   background-color: hsl(0,0%,100%);
   border: 1px solid hsl(240,20%,90%);
   border-radius: 2px;
-  font-size: 14px;
+  font-size: 16px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -932,7 +932,7 @@ exports[`<Search /> snapshots renders filters 1`] = `
   background-color: hsl(0,0%,100%);
   border: 1px solid hsl(240,20%,90%);
   border-radius: 2px;
-  font-size: 14px;
+  font-size: 16px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;


### PR DESCRIPTION
In the context of some of the new work we are doing, search would look better with larger text.

before
<img width="866" alt="Screenshot 2019-06-26 at 20 01 11" src="https://user-images.githubusercontent.com/92439/60204015-4be9df00-984e-11e9-9f9b-56287f623c37.png">

after
<img width="870" alt="Screenshot 2019-06-26 at 20 00 52" src="https://user-images.githubusercontent.com/92439/60204026-55734700-984e-11e9-915f-fddc6a508e98.png">
